### PR TITLE
migrate to parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,213 +1,115 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ |  Copyright 2012 FasterXML.com
+ |
+ |  Licensed under the Apache License, Version 2.0 (the "License");
+ |  you may not use this file except in compliance with the License.
+ |  You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ |  Unless required by applicable law or agreed to in writing, software
+ |  distributed under the License is distributed on an "AS IS" BASIS,
+ |  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ |  See the License for the specific language governing permissions and
+ |  limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>5</version>
-    </parent>
+  <modelVersion>4.0.0</modelVersion>
 
+  <parent>
     <groupId>com.fasterxml</groupId>
-    <artifactId>aalto-xml</artifactId>
-    <packaging>bundle</packaging>
-    <version>0.9.9-SNAPSHOT</version>
-    <name>aalto-xml</name>
-  <description>Ultra-high performance non-blocking XML processor (Stax/Stax2,
-SAX/SAX2)
-</description>
-    <scm>
-        <connection>scm:git:git@github.com:FasterXML/aalto-xml.git</connection>
-        <developerConnection>scm:git:git@github.com:FasterXML/aalto-xml.git</developerConnection>
-    <url>http://github.com/FasterXML/aalto-xml</url>    
-    </scm>
-    <developers>
-        <developer>
-            <id>tatu</id>
-            <name>Tatu Saloranta</name>
-            <email>tatu@fasterxml.com</email>
-        </developer>
-    </developers>
-    <prerequisites>
-        <maven>2.2.1</maven>
-    </prerequisites>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-    <licenses>
-     <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
-     </license>
-    </licenses>
-    <organization>
-     <name>Fasterxml.com</name>
-     <url>http://fasterxml.com</url>
-    </organization>
+    <artifactId>oss-parent</artifactId>
+    <version>2-SNAPSHOT</version>
+  </parent>
 
-    <dependencies>
-      <!-- Not much; just APIs we implement -->
-      <!-- note: we do need Stax2 api (javax.xml.stream); but
-           it comes with JDK 1.6, which is baseline for Aalto
-        -->
-      <dependency>
-        <groupId>org.codehaus.woodstox</groupId>
-        <artifactId>stax2-api</artifactId>
-        <version>3.0.3</version>
-      </dependency>
-      <!-- Test dependencies -->
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.8.2</version>
-        <scope>test</scope>
-      </dependency>
-    </dependencies>
+  <artifactId>aalto-xml</artifactId>
+  <version>0.9.9-SNAPSHOT</version>
+  <packaging>jar</packaging>
 
-    <build>
-      <plugins>
-        <!-- Compilation: require JDK 1.6 -->
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>  
-          <configuration>
-            <source>1.6</source>  
-            <target>1.6</target>  
-          </configuration>  
-        </plugin>
-        <!-- Also build source jar -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-source-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>attach-sources</id>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <!-- Need to provide javadocs -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.6</version>
-          <configuration>
-              <encoding>UTF-8</encoding>
-              <links>
-                  <link>http://java.sun.com/javase/6/docs/api/</link>
-              </links>
-          </configuration>
-          <executions>
-              <execution>
-                  <id>attach-javadocs</id>
-                  <phase>verify</phase>
-                  <goals>
-                      <goal>jar</goal>
-                  </goals>
-              </execution>
-          </executions>
-        </plugin>
-        <!-- Plus, let's make jars OSGi bundles as well  -->
-        <plugin>
-          <groupId>org.apache.felix</groupId>
-          <artifactId>maven-bundle-plugin</artifactId>
-          <extensions>true</extensions>
-          <configuration>
-            <instructions>
-              <Bundle-Name>${project.name}</Bundle-Name>
-              <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-              <Bundle-Description>${project.description}</Bundle-Description>
-              <Import-Package>
-javax.xml.namespace, javax.xml.parsers, javax.xml.stream, javax.xml.stream.util,
+  <name>aalto-xml</name>
+  <description>Ultra-high performance non-blocking XML processor (Stax/Stax2, SAX/SAX2)
+  </description>
+
+  <scm>
+    <connection>scm:git:git@github.com:FasterXML/aalto-xml.git</connection>
+    <developerConnection>scm:git:git@github.com:FasterXML/aalto-xml.git</developerConnection>
+    <url>http://github.com/FasterXML/aalto-xml</url>
+  </scm>
+
+  <properties>
+    <!--
+     | Compilation: require JDK 1.6
+    -->
+    <javac.src.version>1.6</javac.src.version>
+    <javac.target.version>1.6</javac.target.version>
+    <!--
+     | Configuration properties for the OSGi maven-bundle-plugin
+    -->
+    <osgi.export>${project.groupId}.aalto.*;version=${project.version}</osgi.export>
+    <osgi.import>javax.xml.namespace, javax.xml.parsers, javax.xml.stream, javax.xml.stream.util,
 javax.xml.transform, javax.xml.transform.dom, javax.xml.transform.sax, javax.xml.transform.stream,
 org.codehaus.stax2, org.codehaus.stax2.io, org.codehaus.stax2.ri, org.codehaus.stax2.typed,
 org.codehaus.stax2.validation,
 org.codehaus.stax2.ri.dom, org.codehaus.stax2.ri.evt, org.codehaus.stax2.ri.typed,
 org.w3c.dom,
-org.xml.sax, org.xml.sax.ext, org.xml.sax.helpers
-</Import-Package>
-              <DynamicImport-Package>
-</DynamicImport-Package>
-              <Private-Package>
-</Private-Package>
-              <Export-Package>
-com.fasterxml.aalto*
-</Export-Package>
-            </instructions>
-          </configuration>
-        </plugin>
-        <!-- Need GPG signatures for releases -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>2.0</version>
-          <configuration>
-            <mavenExecutorId>forked-path</mavenExecutorId>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <includes>
-              <include>**/Test*.java</include>
-            </includes>
-            <excludes>
-              <exclude>**/Base*</exclude>
-              <exclude>**/*$*</exclude>
-            </excludes>
-            <reportFormat>${surefire.format}</reportFormat>
-            <useFile>${surefire.usefile}</useFile>
-            <forkMode>${surefire.fork.mode}</forkMode>
-            <childDelegation>false</childDelegation>
-            <argLine>${surefire.fork.vmargs}</argLine>
-            <systemProperties>
-              <property>
-                <name>java.awt.headless</name>
-                <value>${java.awt.headless}</value>
-              </property>
-              <property>
-                <name>surefire.fork.vmargs</name>
-                <value>${surefire.fork.vmargs}</value>
-              </property>
-            </systemProperties>
-          </configuration>
-        </plugin>
-      </plugins>
-    </build>
+org.xml.sax, org.xml.sax.ext, org.xml.sax.helpers</osgi.import>
+  </properties>
 
-    <profiles>
-        <profile>
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+  <dependencies>
+    <!--
+     | Not much; just APIs we implement
+     | note: we do need Stax2 api (javax.xml.stream); but
+     | it comes with JDK 1.6, which is baseline for Aalto
+    -->
+    <dependency>
+      <groupId>org.codehaus.woodstox</groupId>
+      <artifactId>stax2-api</artifactId>
+      <version>3.0.3</version>
+    </dependency>
+    <!--
+     | Test dependencies
+    -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.8.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-    <!-- NOTE: repositories from parent POM -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/Test*.java</include>
+          </includes>
+          <excludes>
+            <exclude>**/Base*</exclude>
+            <exclude>**/*$*</exclude>
+          </excludes>
+          <reportFormat>${surefire.format}</reportFormat>
+          <useFile>${surefire.usefile}</useFile>
+          <forkMode>${surefire.fork.mode}</forkMode>
+          <childDelegation>false</childDelegation>
+          <argLine>${surefire.fork.vmargs}</argLine>
+          <systemProperties>
+            <property>
+              <name>java.awt.headless</name>
+              <value>${java.awt.headless}</value>
+            </property>
+            <property>
+              <name>surefire.fork.vmargs</name>
+              <value>${surefire.fork.vmargs}</value>
+            </property>
+          </systemProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ |  Copyright 2012 FasterXML.com
+ |
+ |  Licensed under the Apache License, Version 2.0 (the "License");
+ |  you may not use this file except in compliance with the License.
+ |  You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ |  Unless required by applicable law or agreed to in writing, software
+ |  distributed under the License is distributed on an "AS IS" BASIS,
+ |  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ |  See the License for the specific language governing permissions and
+ |  limitations under the License.
+-->
+<project name="${project.name}">
+
+  <custom>
+    <fluidoSkin>
+      <gitHub>
+        <projectId>FasterXML/aalto-xml</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>red</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+
+  <body>
+    <menu ref="reports"/>
+  </body>
+
+</project>


### PR DESCRIPTION
with the current pull I propose to move the Aalto maven build to get benefits to already declared stuff in the parent.

please notice that I used the 2-SNAPSHOT (patched, see previous pull on parent) that contains the missing OSGi stuff on current parent.

Don't hesitate on contact me directly for any question/doubt.

HTH!
-Simo
