### PR TITLE
Corrected AsyncReaderWrapperForByteBuffer

### DIFF
--- a/src/test/java/async/AsyncReaderWrapper.java
+++ b/src/test/java/async/AsyncReaderWrapper.java
@@ -1,0 +1,9 @@
+package async;
+
+import javax.xml.stream.XMLStreamException;
+
+public interface AsyncReaderWrapper {
+    String currentText() throws XMLStreamException;
+    int currentToken() throws XMLStreamException;
+    int nextToken() throws XMLStreamException;
+}

--- a/src/test/java/async/AsyncReaderWrapperForByteArray.java
+++ b/src/test/java/async/AsyncReaderWrapperForByteArray.java
@@ -10,7 +10,7 @@ import com.fasterxml.aalto.AsyncXMLStreamReader;
 /**
  * Helper class used with async parser
  */
-public class AsyncReaderWrapperForByteArray
+public class AsyncReaderWrapperForByteArray implements AsyncReaderWrapper
 {
     private final AsyncXMLStreamReader<AsyncByteArrayFeeder> _streamReader;
     private final byte[] _xml;
@@ -32,14 +32,17 @@ public class AsyncReaderWrapperForByteArray
         }
     }
 
+    @Override
     public String currentText() throws XMLStreamException {
         return _streamReader.getText();
     }
-    
+
+    @Override
     public int currentToken() throws XMLStreamException {
         return _streamReader.getEventType();
     }
-    
+
+    @Override
     public int nextToken() throws XMLStreamException
     {
         int token;

--- a/src/test/java/async/AsyncReaderWrapperForByteBuffer.java
+++ b/src/test/java/async/AsyncReaderWrapperForByteBuffer.java
@@ -1,61 +1,72 @@
 package async;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import javax.xml.stream.XMLStreamException;
 
-import com.fasterxml.aalto.AsyncByteArrayFeeder;
+import com.fasterxml.aalto.AsyncByteBufferFeeder;
 import com.fasterxml.aalto.AsyncXMLStreamReader;
 
 /**
  * Helper class used with async parser
  */
-public class AsyncReaderWrapperForByteBuffer
+public class AsyncReaderWrapperForByteBuffer implements AsyncReaderWrapper
 {
-    private final AsyncXMLStreamReader<AsyncByteArrayFeeder> _streamReader;
+    private final AsyncXMLStreamReader<AsyncByteBufferFeeder> _streamReader;
 
     private final byte[] _xml;
 
     private final int _bytesPerFeed;
     private int _offset = 0;
 
-    public AsyncReaderWrapperForByteBuffer(AsyncXMLStreamReader<AsyncByteArrayFeeder> sr, String xmlString) {
+    private final ByteBuffer _buf;
+
+    public AsyncReaderWrapperForByteBuffer(AsyncXMLStreamReader<AsyncByteBufferFeeder> sr, String xmlString) {
         this(sr, 1, xmlString);
     }
     
-    public AsyncReaderWrapperForByteBuffer(AsyncXMLStreamReader<AsyncByteArrayFeeder> sr, int bytesPerCall, String xmlString)
+    public AsyncReaderWrapperForByteBuffer(AsyncXMLStreamReader<AsyncByteBufferFeeder> sr, int bytesPerCall, String xmlString)
     {
         _streamReader = sr;
         _bytesPerFeed = bytesPerCall;
         try {
             _xml = xmlString.getBytes("UTF-8");
+            _buf = ByteBuffer.allocate(_bytesPerFeed);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
+    @Override
     public String currentText() throws XMLStreamException {
         return _streamReader.getText();
     }
-    
+
+    @Override
     public int currentToken() throws XMLStreamException {
         return _streamReader.getEventType();
     }
-    
+
+    @Override
     public int nextToken() throws XMLStreamException
     {
         int token;
         
         while ((token = _streamReader.next()) == AsyncXMLStreamReader.EVENT_INCOMPLETE) {
-            AsyncByteArrayFeeder feeder = _streamReader.getInputFeeder();
+            _buf.clear();
+            AsyncByteBufferFeeder feeder = _streamReader.getInputFeeder();
             if (!feeder.needMoreInput()) {
                 AsyncTestBase.fail("Got EVENT_INCOMPLETE, could not feed more input");
             }
+
             if (_offset >= _xml.length) { // end-of-input?
                 feeder.endOfInput();
             } else {
                 int amount = Math.min(_bytesPerFeed, _xml.length - _offset);
-                feeder.feedInput(_xml, _offset, amount);
+                _buf.put(_xml, _offset, amount);
+                _buf.flip();
+                feeder.feedInput(_buf);
                 _offset += amount;
             }
         }

--- a/src/test/java/async/AsyncTestBase.java
+++ b/src/test/java/async/AsyncTestBase.java
@@ -18,14 +18,14 @@ abstract class AsyncTestBase extends base.BaseTestCase
         return SPACES.substring(0, Math.min(SPACES.length(), count));
     }
 
-    protected final int verifyStart(AsyncReaderWrapperForByteArray reader) throws Exception
+    protected final int verifyStart(AsyncReaderWrapper reader) throws Exception
     {
         assertTokenType(AsyncXMLStreamReader.EVENT_INCOMPLETE, reader.currentToken());
         assertTokenType(START_DOCUMENT, reader.nextToken());
         return reader.nextToken();
     }
 
-    protected final String collectAsyncText(AsyncReaderWrapperForByteArray reader, int tt) throws XMLStreamException
+    protected final String collectAsyncText(AsyncReaderWrapper reader, int tt) throws XMLStreamException
     {
         StringBuilder sb = new StringBuilder();
         while (reader.currentToken() == tt) {

--- a/src/test/java/async/TestAsyncViaEventReader.java
+++ b/src/test/java/async/TestAsyncViaEventReader.java
@@ -6,52 +6,119 @@ import javax.xml.stream.events.XMLEvent;
 import com.fasterxml.aalto.*;
 import com.fasterxml.aalto.stax.InputFactoryImpl;
 
+import java.nio.ByteBuffer;
+
 /**
  * Set of tests to ensure that it is possible to use Stax {@link XMLEventReader} with
  * async parser.
  */
 public class TestAsyncViaEventReader extends AsyncTestBase
 {
-    public void testSimple() throws Exception
+    public void testSimple_byteArray() throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncFor("<root>a</r".getBytes("UTF-8"));
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = null;
+        try {
+            sr = f.createAsyncFor("<root>a</r".getBytes("UTF-8"));
+            assertTokenType(START_DOCUMENT, sr.next());
 
-        assertTokenType(START_DOCUMENT, sr.next());
-        
-        XMLEventReader er = f.createXMLEventReader(sr);
+            XMLEventReader er = null;
+            try {
+                er = f.createXMLEventReader(sr);
 
-        XMLEvent evt = er.nextEvent();
-        assertTokenType(START_DOCUMENT, evt.getEventType());
+                XMLEvent evt = er.nextEvent();
+                assertTokenType(START_DOCUMENT, evt.getEventType());
 
-        evt = er.nextEvent();
-        assertTokenType(START_ELEMENT, evt.getEventType());
-        assertEquals("root", sr.getLocalName());
+                evt = er.nextEvent();
+                assertTokenType(START_ELEMENT, evt.getEventType());
+                assertEquals("root", sr.getLocalName());
 
-        evt = er.nextEvent();
-        assertTokenType(CHARACTERS, evt.getEventType());
-        assertEquals("a", sr.getText());
-        
-        // then need more input
-        evt = er.nextEvent();
-        assertTokenType(AsyncXMLStreamReader.EVENT_INCOMPLETE, evt.getEventType());
+                evt = er.nextEvent();
+                assertTokenType(CHARACTERS, evt.getEventType());
+                assertEquals("a", sr.getText());
 
-        byte[] b = "oot>".getBytes("UTF-8");
-        sr.getInputFeeder().feedInput(b, 0, b.length);
+                // then need more input
+                evt = er.nextEvent();
+                assertTokenType(AsyncXMLStreamReader.EVENT_INCOMPLETE, evt.getEventType());
 
-        evt = er.nextEvent();
-        assertTokenType(END_ELEMENT, evt.getEventType());
-        assertEquals("root", sr.getLocalName());
+                byte[] b = "oot>".getBytes("UTF-8");
+                sr.getInputFeeder().feedInput(b, 0, b.length);
 
-        evt = er.nextEvent();
-        assertTokenType(AsyncXMLStreamReader.EVENT_INCOMPLETE, evt.getEventType());
+                evt = er.nextEvent();
+                assertTokenType(END_ELEMENT, evt.getEventType());
+                assertEquals("root", sr.getLocalName());
 
-        sr.getInputFeeder().endOfInput();
-        evt = er.nextEvent();
-        assertTokenType(END_DOCUMENT, evt.getEventType());
-        
-        assertFalse(er.hasNext());
-        
-        sr.close();
+                evt = er.nextEvent();
+                assertTokenType(AsyncXMLStreamReader.EVENT_INCOMPLETE, evt.getEventType());
+
+                sr.getInputFeeder().endOfInput();
+                evt = er.nextEvent();
+                assertTokenType(END_DOCUMENT, evt.getEventType());
+
+                assertFalse(er.hasNext());
+            } finally {
+                if(er != null) {
+                    er.close();
+                }
+            }
+        } finally {
+            if(sr != null) {
+                sr.close();
+            }
+        }
+    }
+
+    public void testSimple_byteBuffer() throws Exception
+    {
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr = null;
+        try {
+            sr = f.createAsyncFor(ByteBuffer.wrap("<root>a</r".getBytes("UTF-8")));
+            assertTokenType(START_DOCUMENT, sr.next());
+
+            XMLEventReader er = null;
+            try {
+                er = f.createXMLEventReader(sr);
+
+                XMLEvent evt = er.nextEvent();
+                assertTokenType(START_DOCUMENT, evt.getEventType());
+
+                evt = er.nextEvent();
+                assertTokenType(START_ELEMENT, evt.getEventType());
+                assertEquals("root", sr.getLocalName());
+
+                evt = er.nextEvent();
+                assertTokenType(CHARACTERS, evt.getEventType());
+                assertEquals("a", sr.getText());
+
+                // then need more input
+                evt = er.nextEvent();
+                assertTokenType(AsyncXMLStreamReader.EVENT_INCOMPLETE, evt.getEventType());
+
+                byte[] b = "oot>".getBytes("UTF-8");
+                sr.getInputFeeder().feedInput(ByteBuffer.wrap(b));
+
+                evt = er.nextEvent();
+                assertTokenType(END_ELEMENT, evt.getEventType());
+                assertEquals("root", sr.getLocalName());
+
+                evt = er.nextEvent();
+                assertTokenType(AsyncXMLStreamReader.EVENT_INCOMPLETE, evt.getEventType());
+
+                sr.getInputFeeder().endOfInput();
+                evt = er.nextEvent();
+                assertTokenType(END_DOCUMENT, evt.getEventType());
+
+                assertFalse(er.hasNext());
+            } finally {
+                if(er != null) {
+                    er.close();
+                }
+            }
+        } finally {
+            if(sr != null) {
+                sr.close();
+            }
+        }
     }
 }

--- a/src/test/java/async/TestCDataParsing.java
+++ b/src/test/java/async/TestCDataParsing.java
@@ -3,6 +3,7 @@ package async;
 import javax.xml.stream.XMLStreamConstants;
 
 import com.fasterxml.aalto.AsyncByteArrayFeeder;
+import com.fasterxml.aalto.AsyncByteBufferFeeder;
 import com.fasterxml.aalto.AsyncXMLInputFactory;
 import com.fasterxml.aalto.AsyncXMLStreamReader;
 import com.fasterxml.aalto.stax.InputFactoryImpl;
@@ -45,12 +46,37 @@ public class TestCDataParsing extends AsyncTestBase
 
     private final static String XML = "<root><![CDATA[cdata\r\n&] ]] stuff]]>...<![CDATA[this\r\r and Unicode: "+UNICODE_SEGMENT+"!]]></root>";
 
-    private void _testCData(int chunkSize, String SPC) throws Exception
+    private void _testCData(final int chunkSize, final String SPC) throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, SPC + XML);
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
 
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, SPC + XML);
+            _testCData(sr_array, reader_array);
+        } finally {
+            if(sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, SPC + XML);
+            _testCData(sr_buffer, reader_buffer);
+        } finally {
+            if(sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testCData(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
         int t = verifyStart(reader);
         assertTokenType(START_ELEMENT, t);
         assertEquals("root", sr.getLocalName());
@@ -79,12 +105,37 @@ public class TestCDataParsing extends AsyncTestBase
         assertFalse(sr.hasNext());
     }
 
-    private void _testCDataSkip(int chunkSize, String SPC) throws Exception
+    private void _testCDataSkip(final int chunkSize, final String SPC) throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, SPC + XML);
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
 
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, SPC + XML);
+            _testCDataSkip(sr_array, reader_array);
+        } finally {
+            if(sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, SPC + XML);
+            _testCDataSkip(sr_buffer, reader_buffer);
+        } finally {
+            if(sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testCDataSkip(AsyncXMLStreamReader<?> sr, AsyncReaderWrapper reader) throws Exception
+    {
         int t = verifyStart(reader);
         assertTokenType(START_ELEMENT, t);
         assertEquals("root", sr.getLocalName());

--- a/src/test/java/async/TestCharactersParsing.java
+++ b/src/test/java/async/TestCharactersParsing.java
@@ -3,6 +3,7 @@ package async;
 import javax.xml.stream.XMLStreamConstants;
 
 import com.fasterxml.aalto.AsyncByteArrayFeeder;
+import com.fasterxml.aalto.AsyncByteBufferFeeder;
 import com.fasterxml.aalto.AsyncXMLInputFactory;
 import com.fasterxml.aalto.AsyncXMLStreamReader;
 import com.fasterxml.aalto.stax.InputFactoryImpl;
@@ -93,13 +94,39 @@ public class TestCharactersParsing extends AsyncTestBase
     /**********************************************************************
      */
     
-    private void _testLinefeeds(int chunkSize, boolean checkValues, String SPC) throws Exception
+    private void _testLinefeeds(final int chunkSize, final boolean checkValues, final String SPC) throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        final String XML = SPC+"<root>\rFirst\r\nSecond\nThird: "+UNICODE_SEGMENT+"</root>";
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, XML);
+        final String XML = SPC + "<root>\rFirst\r\nSecond\nThird: " + UNICODE_SEGMENT + "</root>";
 
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, XML);
+            _testLinefeeds(sr_array, reader_array, checkValues);
+        } finally {
+            if(sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, XML);
+            _testLinefeeds(sr_buffer, reader_buffer, checkValues);
+        } finally {
+            if(sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testLinefeeds(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader, final boolean checkValues) throws Exception
+    {
         assertTokenType(START_ELEMENT, verifyStart(reader));
         if (checkValues) {
             assertEquals("root", sr.getLocalName());
@@ -123,13 +150,39 @@ public class TestCharactersParsing extends AsyncTestBase
         assertFalse(sr.hasNext());
     }
 
-    private void _testTextWithEntities(int chunkSize, boolean checkValues, String SPC) throws Exception
+    private void _testTextWithEntities(final int chunkSize, final boolean checkValues, final String SPC) throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        final String XML = SPC+"<root>a&lt;b\rMOT</root>";
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, XML);
+        final String XML = SPC + "<root>a&lt;b\rMOT</root>";
 
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, XML);
+            _testTextWithEntities(sr_array, reader_array, checkValues);
+        } finally {
+            if (sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, XML);
+            _testTextWithEntities(sr_buffer, reader_buffer, checkValues);
+        } finally {
+            if (sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testTextWithEntities(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader, final boolean checkValues) throws Exception
+    {
         // should start with START_DOCUMENT, but for now skip
         int t = verifyStart(reader);
         assertTokenType(START_ELEMENT, t);
@@ -153,13 +206,39 @@ public class TestCharactersParsing extends AsyncTestBase
         assertFalse(sr.hasNext());
     }
 
-    private void _testTextWithNumericEntities(int chunkSize, boolean checkValues, String SPC) throws Exception
+    private void _testTextWithNumericEntities(final int chunkSize, final boolean checkValues, final String SPC) throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        final String XML = SPC+"<root>&#60;tag&#x3e;!</root>";
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, XML);
+        final String XML = SPC + "<root>&#60;tag&#x3e;!</root>";
 
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, XML);
+            _testTextWithNumericEntities(sr_array, reader_array, checkValues);
+        } finally {
+            if (sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, XML);
+            _testTextWithNumericEntities(sr_buffer, reader_buffer, checkValues);
+        } finally {
+            if (sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testTextWithNumericEntities(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader, final boolean checkValues) throws Exception
+    {
         // should start with START_DOCUMENT, but for now skip
         int t = verifyStart(reader);
         assertTokenType(START_ELEMENT, t);

--- a/src/test/java/async/TestCommentParsing.java
+++ b/src/test/java/async/TestCommentParsing.java
@@ -1,6 +1,7 @@
 package async;
 
 import com.fasterxml.aalto.AsyncByteArrayFeeder;
+import com.fasterxml.aalto.AsyncByteBufferFeeder;
 import com.fasterxml.aalto.AsyncXMLInputFactory;
 import com.fasterxml.aalto.AsyncXMLStreamReader;
 import com.fasterxml.aalto.stax.InputFactoryImpl;
@@ -41,11 +42,37 @@ public class TestCommentParsing extends AsyncTestBase
 
     private final static String XML = "<!--comments&s\r\ntuf-fy>--><root><!----></root><!--\nHi - "+UNICODE_SEGMENT+" - ho->-->";
     
-    private void _testComments(String spaces, int chunkSize) throws Exception
+    private void _testComments(final String spaces, final int chunkSize) throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, spaces+XML);
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, spaces + XML);
+            _testComments(sr_array, reader_array);
+        } finally {
+            if (sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, spaces + XML);
+            _testComments(sr_buffer, reader_buffer);
+        } finally {
+            if (sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testComments(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
         int t = verifyStart(reader);
         assertTokenType(COMMENT, t);
         assertEquals("comments&s\ntuf-fy>", sr.getText());
@@ -60,11 +87,37 @@ public class TestCommentParsing extends AsyncTestBase
         assertTokenType(END_DOCUMENT, reader.nextToken());
     }
 
-    private void _testSkipComments(String spaces, int chunkSize) throws Exception
+    private void _testSkipComments(final String spaces, final int chunkSize) throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, spaces+XML);
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, spaces + XML);
+            _testSkipComments(sr_array, reader_array);
+        } finally {
+            if (sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, spaces + XML);
+            _testSkipComments(sr_buffer, reader_buffer);
+        } finally {
+            if (sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testSkipComments(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
         int t = verifyStart(reader);
         assertTokenType(COMMENT, t);
         assertTokenType(START_ELEMENT, reader.nextToken());

--- a/src/test/java/async/TestDoctypeParsing.java
+++ b/src/test/java/async/TestDoctypeParsing.java
@@ -6,6 +6,7 @@ import javax.xml.stream.XMLStreamException;
 
 
 import com.fasterxml.aalto.AsyncByteArrayFeeder;
+import com.fasterxml.aalto.AsyncByteBufferFeeder;
 import com.fasterxml.aalto.AsyncXMLInputFactory;
 import com.fasterxml.aalto.AsyncXMLStreamReader;
 import com.fasterxml.aalto.stax.InputFactoryImpl;
@@ -79,12 +80,39 @@ public class TestDoctypeParsing extends AsyncTestBase
     /**********************************************************************
      */
     
-    private void _testSimplest(String spaces, int chunkSize) throws Exception
+    private void _testSimplest(final String spaces, final int chunkSize) throws Exception
     {
-        String XML = spaces+"<!DOCTYPE root>  <root />";
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, XML);
+        final String XML = spaces + "<!DOCTYPE root>  <root />";
+
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, XML);
+            _testSimplest(sr_array, reader_array);
+        } finally {
+            if (sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, XML);
+            _testSimplest(sr_buffer, reader_buffer);
+        } finally {
+            if (sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testSimplest(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
         int t = verifyStart(reader);
         assertTokenType(DTD, t);
         // as per Stax API, can't call getLocalName (ugh), but Stax2 gives us this:
@@ -93,59 +121,137 @@ public class TestDoctypeParsing extends AsyncTestBase
         assertTokenType(END_ELEMENT, reader.nextToken());
     }
 
-    private void _testWithIds(String spaces, int chunkSize) throws Exception
+    private void _testWithIds(final String spaces, final int chunkSize) throws Exception
     {
         final String PUBLIC_ID = "some-id";
         final String SYSTEM_ID = "file:/something";
-        String XML = spaces+"<!DOCTYPE root PUBLIC '"+PUBLIC_ID+"' \""+SYSTEM_ID+"\"><root/>";
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, XML);
+        final String XML = spaces + "<!DOCTYPE root PUBLIC '" + PUBLIC_ID + "' \"" + SYSTEM_ID + "\"><root/>";
+
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, XML);
+            _testWithIds(sr_array, reader_array, PUBLIC_ID, SYSTEM_ID);
+        } finally {
+            if (sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, XML);
+            _testWithIds(sr_buffer, reader_buffer, PUBLIC_ID, SYSTEM_ID);
+        } finally {
+            if (sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testWithIds(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader, final String PUBLIC_ID, final String SYSTEM_ID) throws Exception
+    {
         int t = verifyStart(reader);
         assertTokenType(DTD, t);
         assertTokenType(DTD, sr.getEventType());
         assertEquals("root", sr.getPrefixedName());
-        assertEquals(SYSTEM_ID, sr.getDTDInfo().getDTDSystemId());
         assertEquals(PUBLIC_ID, sr.getDTDInfo().getDTDPublicId());
+        assertEquals(SYSTEM_ID, sr.getDTDInfo().getDTDSystemId());
 
         assertTokenType(START_ELEMENT, reader.nextToken());
         assertTokenType(END_ELEMENT, reader.nextToken());
-        sr.close();
     }
 
-    private void _testFull(String spaces, boolean checkValue, int chunkSize) throws Exception
+    private void _testFull(final String spaces, final boolean checkValue, final int chunkSize) throws Exception
     {
-        final String INTERNAL_SUBSET = "<!--My dtd-->\n"
-            +"<!ELEMENT html (head, body)>"
-            +"<!ATTLIST head title CDATA #IMPLIED>"
-            ;
         final String SYSTEM_ID = "file:/something";
-        String XML = spaces+"<!DOCTYPE root SYSTEM '"+SYSTEM_ID+"' ["+INTERNAL_SUBSET+"]>\n<root/>";
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, XML);
+        final String INTERNAL_SUBSET = "<!--My dtd-->\n"
+                + "<!ELEMENT html (head, body)>"
+                + "<!ATTLIST head title CDATA #IMPLIED>";
+        String XML = spaces + "<!DOCTYPE root SYSTEM '" + SYSTEM_ID + "' [" + INTERNAL_SUBSET + "]>\n<root/>";
+
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, XML);
+            _testFull(sr_array, reader_array, checkValue, SYSTEM_ID, INTERNAL_SUBSET);
+        } finally {
+            if (sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, XML);
+            _testFull(sr_buffer, reader_buffer, checkValue, SYSTEM_ID, INTERNAL_SUBSET);
+        } finally {
+            if (sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testFull(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader, final boolean checkValue, final String SYSTEM_ID, final String INTERNAL_SUBSET) throws Exception
+    {
         int t = verifyStart(reader);
         assertTokenType(DTD, t);
         if (checkValue) {
             assertNull(sr.getDTDInfo().getDTDPublicId());
             assertEquals(SYSTEM_ID, sr.getDTDInfo().getDTDSystemId());
             assertEquals("root", sr.getPrefixedName());
-            String subset = sr.getText();
+            final String subset = sr.getText();
             assertEquals(INTERNAL_SUBSET, subset);
         }
         assertTokenType(START_ELEMENT, reader.nextToken());
         assertTokenType(END_ELEMENT, reader.nextToken());
         assertTokenType(END_DOCUMENT, reader.nextToken());
         assertFalse(sr.hasNext());
-        sr.close();
     }
 
-    private void _testInvalidDup(String spaces, int chunkSize) throws Exception
+    private void _testInvalidDup(final String spaces, final int chunkSize) throws Exception
     {
-        String XML = spaces+"<!DOCTYPE root> <!DOCTYPE root> <root />";
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, XML);
+        final String XML = spaces + "<!DOCTYPE root> <!DOCTYPE root> <root />";
+
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, XML);
+            _testInvalidDup(sr_array, reader_array);
+        } finally {
+            if (sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, XML);
+            _testInvalidDup(sr_buffer, reader_buffer);
+        } finally {
+            if (sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testInvalidDup(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
         int t = verifyStart(reader);
         assertTokenType(DTD, t);
         assertEquals("root", sr.getPrefixedName());
@@ -156,7 +262,5 @@ public class TestDoctypeParsing extends AsyncTestBase
         } catch (XMLStreamException e) {
             verifyException(e, "Duplicate DOCTYPE declaration");
         }
-        sr.close();
     }
-
 }

--- a/src/test/java/async/TestPIParsing.java
+++ b/src/test/java/async/TestPIParsing.java
@@ -1,6 +1,7 @@
 package async;
 
 import com.fasterxml.aalto.AsyncByteArrayFeeder;
+import com.fasterxml.aalto.AsyncByteBufferFeeder;
 import com.fasterxml.aalto.AsyncXMLInputFactory;
 import com.fasterxml.aalto.AsyncXMLStreamReader;
 import com.fasterxml.aalto.stax.InputFactoryImpl;
@@ -41,11 +42,37 @@ public class TestPIParsing extends AsyncTestBase
 
     private final static String XML = "<?p    i ?><root><?pi \nwith\r\ndata??><?x \nfoo> "+UNICODE_SEGMENT+" bar? ?></root><?proc    \r?>";
     
-    private void _testPI(String spaces, int chunkSize) throws Exception
+    private void _testPI(final String spaces, final int chunkSize) throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, spaces+XML);
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, spaces + XML);
+            _testPI(sr_array, reader_array);
+        } finally {
+            if (sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, spaces + XML);
+            _testPI(sr_buffer, reader_buffer);
+        } finally {
+            if (sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testPI(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
         int t = verifyStart(reader);
         assertTokenType(PROCESSING_INSTRUCTION, t);
         assertEquals("p", sr.getPITarget());
@@ -66,11 +93,37 @@ public class TestPIParsing extends AsyncTestBase
         assertTokenType(END_DOCUMENT, reader.nextToken());
     }
 
-    private void _testPISkip(String spaces, int chunkSize) throws Exception
+    private void _testPISkip(final String spaces, final int chunkSize) throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, spaces+XML);
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, spaces + XML);
+            _testPISkip(sr_array, reader_array);
+        } finally {
+            if (sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, spaces + XML);
+            _testPISkip(sr_buffer, reader_buffer);
+        } finally {
+            if (sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testPISkip(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
         int t = verifyStart(reader);
         assertTokenType(PROCESSING_INSTRUCTION, t);
         assertTokenType(START_ELEMENT, reader.nextToken());

--- a/src/test/java/async/TestSurrogates.java
+++ b/src/test/java/async/TestSurrogates.java
@@ -1,6 +1,7 @@
 package async;
 
 import com.fasterxml.aalto.AsyncByteArrayFeeder;
+import com.fasterxml.aalto.AsyncByteBufferFeeder;
 import com.fasterxml.aalto.AsyncXMLInputFactory;
 import com.fasterxml.aalto.AsyncXMLStreamReader;
 import com.fasterxml.aalto.stax.InputFactoryImpl;
@@ -38,11 +39,37 @@ public class TestSurrogates extends AsyncTestBase
         }
     }
     
-    private void _testWithSurrogate(String spaces, int chunkSize) throws Exception
+    private void _testWithSurrogate(final String spaces, final int chunkSize) throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, spaces+DOC);
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, spaces + DOC);
+            _testWithSurrogate(sr_array, reader_array);
+        } finally {
+            if (sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, spaces + DOC);
+            _testWithSurrogate(sr_buffer, reader_buffer);
+        } finally {
+            if (sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testWithSurrogate(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
         int t = verifyStart(reader);
         assertTokenType(START_ELEMENT, t);
         assertEquals("value", sr.getLocalName());
@@ -52,20 +79,44 @@ public class TestSurrogates extends AsyncTestBase
         assertTokenType(END_ELEMENT, reader.currentToken());
         assertEquals("value", sr.getLocalName());
         assertTokenType(END_DOCUMENT, reader.nextToken());
-        sr.close();
     }
 
-    private void _testSkipWithSurrogate(String spaces, int chunkSize) throws Exception
+    private void _testSkipWithSurrogate(final String spaces, final int chunkSize) throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-        AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, spaces+DOC);
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+
+        //test for byte array
+        AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+        try {
+            sr_array = f.createAsyncForByteArray();
+            final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, spaces + DOC);
+            _testSkipWithSurrogate(sr_array, reader_array);
+        } finally {
+            if (sr_array != null) {
+                sr_array.close();
+            }
+        }
+
+        //test for byte buffer
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+        try {
+            sr_buffer = f.createAsyncForByteBuffer();
+            final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, spaces + DOC);
+            _testSkipWithSurrogate(sr_buffer, reader_buffer);
+        } finally {
+            if (sr_buffer != null) {
+                sr_buffer.close();
+            }
+        }
+    }
+
+    private void _testSkipWithSurrogate(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
         int t = verifyStart(reader);
         assertTokenType(START_ELEMENT, t);
         assertTokenType(CHARACTERS, reader.nextToken());
         assertTokenType(END_ELEMENT, reader.nextToken());
         assertTokenType(END_DOCUMENT, reader.nextToken());
         assertFalse(sr.hasNext());
-        sr.close();
     }
 }

--- a/src/test/java/async/TestXmlDeclaration.java
+++ b/src/test/java/async/TestXmlDeclaration.java
@@ -1,6 +1,7 @@
 package async;
 
 import com.fasterxml.aalto.AsyncByteArrayFeeder;
+import com.fasterxml.aalto.AsyncByteBufferFeeder;
 import com.fasterxml.aalto.AsyncXMLInputFactory;
 import com.fasterxml.aalto.AsyncXMLStreamReader;
 import com.fasterxml.aalto.stax.InputFactoryImpl;
@@ -13,104 +14,229 @@ public class TestXmlDeclaration extends AsyncTestBase
 
     public void testNoDeclaration() throws Exception
     {
-        AsyncXMLInputFactory f = new InputFactoryImpl();
-        for (String XML : new String[] { "   <root />", "<root/>" }) {
-            for (int chunkSize : CHUNK_SIZES) {
-                AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-                AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, XML);
-                assertEquals(EVENT_INCOMPLETE, reader.currentToken());
-                assertTokenType(START_DOCUMENT, reader.nextToken());
-                // no info, however; except for encoding auto-detection
-                assertNull(sr.getCharacterEncodingScheme());
-                assertEquals("UTF-8", sr.getEncoding());
-                assertNull(sr.getVersion());
-                assertFalse(sr.standaloneSet());
-    
-                assertTokenType(START_ELEMENT, reader.nextToken());
-                assertEquals("root", sr.getLocalName());
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
+        for (final String XML : new String[] { "   <root />", "<root/>" }) {
+            for (final int chunkSize : CHUNK_SIZES) {
+                //test for byte array
+                AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+                try {
+                    sr_array = f.createAsyncForByteArray();
+                    final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, XML);
+                    _testNoDeclaration(sr_array, reader_array);
+                } finally {
+                    if(sr_array != null) {
+                        sr_array.close();
+                    }
+                }
+
+                //test for byte buffer
+                AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+                try {
+                    sr_buffer = f.createAsyncForByteBuffer();
+                    final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, XML);
+                    _testNoDeclaration(sr_buffer, reader_buffer);
+                } finally {
+                    if(sr_buffer != null) {
+                        sr_buffer.close();
+                    }
+                }
             }
         }
     }
 
+    private void _testNoDeclaration(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
+        assertEquals(EVENT_INCOMPLETE, reader.currentToken());
+        assertTokenType(START_DOCUMENT, reader.nextToken());
+        // no info, however; except for encoding auto-detection
+        assertNull(sr.getCharacterEncodingScheme());
+        assertEquals("UTF-8", sr.getEncoding());
+        assertNull(sr.getVersion());
+        assertFalse(sr.standaloneSet());
+
+        assertTokenType(START_ELEMENT, reader.nextToken());
+        assertEquals("root", sr.getLocalName());
+    }
+
     public void testVersionOnlyDeclaration() throws Exception
     {
-        String XML = "<?xml version='1.0' ?><root />";
-        AsyncXMLInputFactory f = new InputFactoryImpl();
+        final String XML = "<?xml version='1.0' ?><root />";
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
 
-        for (int chunkSize : CHUNK_SIZES) {
-            AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-            AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, XML);
-            assertEquals(EVENT_INCOMPLETE, reader.currentToken());
-            assertTokenType(START_DOCUMENT, reader.nextToken());
-            assertNull(sr.getCharacterEncodingScheme());
-            assertEquals("UTF-8", sr.getEncoding());
-            assertEquals("1.0", sr.getVersion());
-            assertFalse(sr.standaloneSet());
+        for (final int chunkSize : CHUNK_SIZES) {
+            //test for byte array
+            AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+            try {
+                sr_array = f.createAsyncForByteArray();
+                final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, XML);
+                _testVersionOnlyDeclaration(sr_array, reader_array);
+            } finally {
+                if(sr_array != null) {
+                    sr_array.close();
+                }
+            }
 
-            assertTokenType(START_ELEMENT, reader.nextToken());
-            assertEquals("root", sr.getLocalName());
+            //test for byte buffer
+            AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+            try {
+                sr_buffer = f.createAsyncForByteBuffer();
+                final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, XML);
+                _testVersionOnlyDeclaration(sr_buffer, reader_buffer);
+            } finally {
+                if(sr_buffer != null) {
+                    sr_buffer.close();
+                }
+            }
         }
+    }
+
+    private void _testVersionOnlyDeclaration(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
+        assertEquals(EVENT_INCOMPLETE, reader.currentToken());
+        assertTokenType(START_DOCUMENT, reader.nextToken());
+        assertNull(sr.getCharacterEncodingScheme());
+        assertEquals("UTF-8", sr.getEncoding());
+        assertEquals("1.0", sr.getVersion());
+        assertFalse(sr.standaloneSet());
+
+        assertTokenType(START_ELEMENT, reader.nextToken());
+        assertEquals("root", sr.getLocalName());
     }
 
     public void testEncodingDeclaration() throws Exception
     {
-        String XML = "<?xml version= \"1.0\"   encoding='UTF-8' ?><root/>";
-        AsyncXMLInputFactory f = new InputFactoryImpl();
+        final String XML = "<?xml version= \"1.0\"   encoding='UTF-8' ?><root/>";
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
 
-        for (int chunkSize : CHUNK_SIZES) {
-            AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-            AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, XML);
-            assertEquals(EVENT_INCOMPLETE, reader.currentToken());
-            assertTokenType(START_DOCUMENT, reader.nextToken());
-            assertEquals("UTF-8", sr.getEncoding());
-            assertEquals("UTF-8", sr.getCharacterEncodingScheme());
-            assertEquals("1.0", sr.getVersion());
-            assertFalse(sr.standaloneSet());
+        for (final int chunkSize : CHUNK_SIZES) {
+            //test for byte array
+            AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+            try {
+                sr_array = f.createAsyncForByteArray();
+                final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, XML);
+                _testEncodingDeclaration(sr_array, reader_array);
+            } finally {
+                if(sr_array != null) {
+                    sr_array.close();
+                }
+            }
 
-            assertTokenType(START_ELEMENT, reader.nextToken());
-            assertEquals("root", sr.getLocalName());
+            //test for byte buffer
+            AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+            try {
+                sr_buffer = f.createAsyncForByteBuffer();
+                final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, XML);
+                _testEncodingDeclaration(sr_buffer, reader_buffer);
+            } finally {
+                if(sr_buffer != null) {
+                    sr_buffer.close();
+                }
+            }
         }
+    }
+
+    private void _testEncodingDeclaration(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
+        assertEquals(EVENT_INCOMPLETE, reader.currentToken());
+        assertTokenType(START_DOCUMENT, reader.nextToken());
+        assertEquals("UTF-8", sr.getEncoding());
+        assertEquals("UTF-8", sr.getCharacterEncodingScheme());
+        assertEquals("1.0", sr.getVersion());
+        assertFalse(sr.standaloneSet());
+
+        assertTokenType(START_ELEMENT, reader.nextToken());
+        assertEquals("root", sr.getLocalName());
     }
 
     public void testStandAloneDeclaration() throws Exception
     {
-        String XML = "<?xml version  ='1.0' encoding=\"UTF-8\"  standalone='yes' ?>  <root />";
-        AsyncXMLInputFactory f = new InputFactoryImpl();
+        final String XML = "<?xml version  ='1.0' encoding=\"UTF-8\"  standalone='yes' ?>  <root />";
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
 
-        for (int chunkSize : CHUNK_SIZES) {
-            AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-            AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, XML);
-            assertEquals(EVENT_INCOMPLETE, reader.currentToken());
-            assertTokenType(START_DOCUMENT, reader.nextToken());
-            assertEquals("UTF-8", sr.getEncoding());
-            assertEquals("UTF-8", sr.getCharacterEncodingScheme());
-            assertEquals("1.0", sr.getVersion());
-            assertTrue(sr.standaloneSet());
-            assertTrue(sr.isStandalone());
+        for (final int chunkSize : CHUNK_SIZES) {
+            //test for byte array
+            AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+            try {
+                sr_array = f.createAsyncForByteArray();
+                final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, XML);
+                _testStandAloneDeclaration(sr_array, reader_array);
+            } finally {
+                if(sr_array != null) {
+                    sr_array.close();
+                }
+            }
 
-            assertTokenType(START_ELEMENT, reader.nextToken());
-            assertEquals("root", sr.getLocalName());
+            //test for byte buffer
+            AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+            try {
+                sr_buffer = f.createAsyncForByteBuffer();
+                final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, XML);
+                _testStandAloneDeclaration(sr_buffer, reader_buffer);
+            } finally {
+                if(sr_buffer != null) {
+                    sr_buffer.close();
+                }
+            }
         }
+    }
+
+    private void _testStandAloneDeclaration(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
+        assertEquals(EVENT_INCOMPLETE, reader.currentToken());
+        assertTokenType(START_DOCUMENT, reader.nextToken());
+        assertEquals("UTF-8", sr.getEncoding());
+        assertEquals("UTF-8", sr.getCharacterEncodingScheme());
+        assertEquals("1.0", sr.getVersion());
+        assertTrue(sr.standaloneSet());
+        assertTrue(sr.isStandalone());
+
+        assertTokenType(START_ELEMENT, reader.nextToken());
+        assertEquals("root", sr.getLocalName());
     }
 
     public void testStandAloneDeclaration2() throws Exception
     {
-        String XML = "<?xml version=\"1.0\" standalone='yes'?>\n<root/>";
-        AsyncXMLInputFactory f = new InputFactoryImpl();
+        final String XML = "<?xml version=\"1.0\" standalone='yes'?>\n<root/>";
+        final AsyncXMLInputFactory f = new InputFactoryImpl();
 
-        for (int chunkSize : CHUNK_SIZES) {
-            AsyncXMLStreamReader<AsyncByteArrayFeeder> sr = f.createAsyncForByteArray();
-            AsyncReaderWrapperForByteArray reader = new AsyncReaderWrapperForByteArray(sr, chunkSize, XML);
-            assertEquals(EVENT_INCOMPLETE, reader.currentToken());
-            assertTokenType(START_DOCUMENT, reader.nextToken());
-            assertEquals("UTF-8", sr.getEncoding());
-            assertNull(sr.getCharacterEncodingScheme());
-            assertEquals("1.0", sr.getVersion());
-            assertTrue(sr.standaloneSet());
-            assertTrue(sr.isStandalone());
+        for (final int chunkSize : CHUNK_SIZES) {
+            //test for byte array
+            AsyncXMLStreamReader<AsyncByteArrayFeeder> sr_array = null;
+            try {
+                sr_array = f.createAsyncForByteArray();
+                final AsyncReaderWrapperForByteArray reader_array = new AsyncReaderWrapperForByteArray(sr_array, chunkSize, XML);
+                _testStandAloneDeclaration2(sr_array, reader_array);
+            } finally {
+                if(sr_array != null) {
+                    sr_array.close();
+                }
+            }
 
-            assertTokenType(START_ELEMENT, reader.nextToken());
-            assertEquals("root", sr.getLocalName());
+            //test for byte buffer
+            AsyncXMLStreamReader<AsyncByteBufferFeeder> sr_buffer = null;
+            try {
+                sr_buffer = f.createAsyncForByteBuffer();
+                final AsyncReaderWrapperForByteBuffer reader_buffer = new AsyncReaderWrapperForByteBuffer(sr_buffer, chunkSize, XML);
+                _testStandAloneDeclaration2(sr_buffer, reader_buffer);
+            } finally {
+                if(sr_buffer != null) {
+                    sr_buffer.close();
+                }
+            }
         }
+    }
+
+    private void _testStandAloneDeclaration2(final AsyncXMLStreamReader<?> sr, final AsyncReaderWrapper reader) throws Exception
+    {
+        assertEquals(EVENT_INCOMPLETE, reader.currentToken());
+        assertTokenType(START_DOCUMENT, reader.nextToken());
+        assertEquals("UTF-8", sr.getEncoding());
+        assertNull(sr.getCharacterEncodingScheme());
+        assertEquals("1.0", sr.getVersion());
+        assertTrue(sr.standaloneSet());
+        assertTrue(sr.isStandalone());
+
+        assertTokenType(START_ELEMENT, reader.nextToken());
+        assertEquals("root", sr.getLocalName());
     }
 }


### PR DESCRIPTION
Previously `AsyncReaderWrapperForByteBuffer` was just a copy of `AsyncReaderWrapperForByteArray` and was not used by any of the tests.

`AsyncReaderWrapperForByteBuffer` now uses `AsyncByteBufferFeeder` as I believe it should.

In addition, all the async tests have been updated to test both `ByteBuffer` and `byte[]` code paths. 
Unfortunately this leads to quite a bit of code duplication in the tests, this could be reduced if we switched to using JUnit annotations and used @RunWith to inject parameters. We could also further reduce code duplication, using `try-with-resources` from Java 7, and function references from Java 8.