### PR TITLE
Bugfix dtd id parser

### DIFF
--- a/src/main/java/com/fasterxml/aalto/async/AsyncByteArrayScanner.java
+++ b/src/main/java/com/fasterxml/aalto/async/AsyncByteArrayScanner.java
@@ -1823,7 +1823,7 @@ public class AsyncByteArrayScanner
                 }
                 {
                     char[] buf = _textBuilder.resetWithEmpty();
-                    if (_inputPtr >= _inputEnd || !parseDtdId(buf, 0)) {
+                    if (_inputPtr >= _inputEnd || !parseDtdId(buf, 0, false)) {
                         _state = STATE_DTD_PUBLIC_ID;
                         break;
                     }
@@ -1833,7 +1833,7 @@ public class AsyncByteArrayScanner
                 continue main_loop;
     
             case STATE_DTD_PUBLIC_ID: 
-                if (!parseDtdId(_textBuilder.getBufferWithoutReset(), _textBuilder.getCurrentLength())) {
+                if (!parseDtdId(_textBuilder.getBufferWithoutReset(), _textBuilder.getCurrentLength(), false)) {
                     break;
                 }
                 verifyAndSetPublicId();
@@ -1863,7 +1863,7 @@ public class AsyncByteArrayScanner
                 }
                 {
                     char[] buf = _textBuilder.resetWithEmpty();
-                    if (_inputPtr >= _inputEnd || !parseDtdId(buf, 0)) {
+                    if (_inputPtr >= _inputEnd || !parseDtdId(buf, 0, true)) {
                         _state = STATE_DTD_SYSTEM_ID;
                         break;
                     }
@@ -1873,7 +1873,7 @@ public class AsyncByteArrayScanner
                 continue main_loop;
 
             case STATE_DTD_SYSTEM_ID: 
-                if (!parseDtdId(_textBuilder.getBufferWithoutReset(), _textBuilder.getCurrentLength())) {
+                if (!parseDtdId(_textBuilder.getBufferWithoutReset(), _textBuilder.getCurrentLength(), true)) {
                     break;
                 }
                 verifyAndSetSystemId();
@@ -1926,7 +1926,7 @@ public class AsyncByteArrayScanner
         return _currToken;
     }
 
-    private final boolean parseDtdId(char[] buffer, int ptr) throws XMLStreamException
+    private final boolean parseDtdId(char[] buffer, int ptr, boolean system) throws XMLStreamException
     {
         final int quote = (int) _elemAttrQuote;
         while (_inputPtr < _inputEnd) {
@@ -1935,9 +1935,8 @@ public class AsyncByteArrayScanner
                 _textBuilder.setCurrentLength(ptr);
                 return true;
             }
-            // this is not exact check; but does work for all legal (valid) characters:
-            if (ch <= INT_SPACE || ch > 0x7E) {
-                reportPrologUnexpChar(true, decodeCharForError((byte) ch), " (not valid in PUBLIC or SYSTEM ID)");
+            if (!system && !validPublicIdChar(ch)) {
+                reportPrologUnexpChar(true, decodeCharForError((byte) ch), " (not valid in " + (system ? "SYSTEM" : "PUBLIC") + " ID)");
             }
             if (ptr >= buffer.length) {
                 buffer = _textBuilder.finishCurrentSegment();

--- a/src/main/java/com/fasterxml/aalto/async/AsyncByteBufferScanner.java
+++ b/src/main/java/com/fasterxml/aalto/async/AsyncByteBufferScanner.java
@@ -1830,7 +1830,7 @@ public class AsyncByteBufferScanner
                 }
                 {
                     char[] buf = _textBuilder.resetWithEmpty();
-                    if (_inputPtr >= _inputEnd || !parseDtdId(buf, 0)) {
+                    if (_inputPtr >= _inputEnd || !parseDtdId(buf, 0, false)) {
                         _state = STATE_DTD_PUBLIC_ID;
                         break;
                     }
@@ -1840,7 +1840,7 @@ public class AsyncByteBufferScanner
                 continue main_loop;
     
             case STATE_DTD_PUBLIC_ID: 
-                if (!parseDtdId(_textBuilder.getBufferWithoutReset(), _textBuilder.getCurrentLength())) {
+                if (!parseDtdId(_textBuilder.getBufferWithoutReset(), _textBuilder.getCurrentLength(), false)) {
                     break;
                 }
                 verifyAndSetPublicId();
@@ -1870,7 +1870,7 @@ public class AsyncByteBufferScanner
                 }
                 {
                     char[] buf = _textBuilder.resetWithEmpty();
-                    if (_inputPtr >= _inputEnd || !parseDtdId(buf, 0)) {
+                    if (_inputPtr >= _inputEnd || !parseDtdId(buf, 0, true)) {
                         _state = STATE_DTD_SYSTEM_ID;
                         break;
                     }
@@ -1880,7 +1880,7 @@ public class AsyncByteBufferScanner
                 continue main_loop;
 
             case STATE_DTD_SYSTEM_ID: 
-                if (!parseDtdId(_textBuilder.getBufferWithoutReset(), _textBuilder.getCurrentLength())) {
+                if (!parseDtdId(_textBuilder.getBufferWithoutReset(), _textBuilder.getCurrentLength(), true)) {
                     break;
                 }
                 verifyAndSetSystemId();
@@ -1933,7 +1933,7 @@ public class AsyncByteBufferScanner
         return _currToken;
     }
 
-    private final boolean parseDtdId(char[] outputBuffer, int outputPtr) throws XMLStreamException
+    private final boolean parseDtdId(char[] outputBuffer, int outputPtr, boolean system) throws XMLStreamException
     {
         final int quote = (int) _elemAttrQuote;
         while (_inputPtr < _inputEnd) {
@@ -1942,9 +1942,8 @@ public class AsyncByteBufferScanner
                 _textBuilder.setCurrentLength(outputPtr);
                 return true;
             }
-            // this is not exact check; but does work for all legal (valid) characters:
-            if (ch <= INT_SPACE || ch > 0x7E) {
-                reportPrologUnexpChar(true, decodeCharForError((byte) ch), " (not valid in PUBLIC or SYSTEM ID)");
+            if (!system && !validPublicIdChar(ch)) {
+                reportPrologUnexpChar(true, decodeCharForError((byte) ch), " (not valid in " + (system ? "SYSTEM" : "PUBLIC") + " ID)");
             }
             if (outputPtr >= outputBuffer.length) {
                 outputBuffer = _textBuilder.finishCurrentSegment();

--- a/src/main/java/com/fasterxml/aalto/async/AsyncByteScanner.java
+++ b/src/main/java/com/fasterxml/aalto/async/AsyncByteScanner.java
@@ -619,6 +619,30 @@ public abstract class AsyncByteScanner
         _textBuilder.append((char) charFromEntity);
     }
 
+    /**
+     * Checks that a character for a PublicId
+     * is valid {@see http://www.w3.org/TR/xml/#NT-PubidLiteral}
+     *
+     * @param c A character
+     * @return true if the character is valid for use in the Public ID
+     * of an XML doctype declaration
+     */
+    protected boolean validPublicIdChar(int c) {
+        return
+            c == 0xA ||                     //<LF>
+            c == 0xD ||                     //<CR>
+            c == 0x20 ||                    //<SPACE>
+            (c >= '@' && c <= 'Z') ||       //@[A-Z]
+            (c >= 'a' && c <= 'z') ||
+            c == '!' ||
+            (c >= 0x23 && c <= 0x25) ||     //#$%
+            (c >= 0x27 && c <= 0x2F) ||     //'()*+,-./
+            (c >= ':' && c <= ';') ||
+            c == '=' ||
+            c == '?' ||
+            c == '_';
+    }
+
     /*
     /**********************************************************************
     /* Internal methods, error handling

--- a/src/test/java/async/TestDoctypeParsing.java
+++ b/src/test/java/async/TestDoctypeParsing.java
@@ -123,8 +123,8 @@ public class TestDoctypeParsing extends AsyncTestBase
 
     private void _testWithIds(final String spaces, final int chunkSize) throws Exception
     {
-        final String PUBLIC_ID = "some-id";
-        final String SYSTEM_ID = "file:/something";
+        final String PUBLIC_ID = "-//OASIS//DTD DITA Topic//EN";
+        final String SYSTEM_ID = "file:/topic.dtd";
         final String XML = spaces + "<!DOCTYPE root PUBLIC '" + PUBLIC_ID + "' \"" + SYSTEM_ID + "\"><root/>";
 
         final AsyncXMLInputFactory f = new InputFactoryImpl();


### PR DESCRIPTION
Updated the parser so that it parses all valid chars for a Public Id and System Id as stated in http://www.w3.org/TR/xml/#NT-PubidLiteral

Previously doctype declarations like the following (incorrectly) failed parsing:

```xml
<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
```