### PR TITLE
Fix of https://github.com/FasterXML/aalto-xml/issues/40

### DIFF
--- a/src/main/java/com/fasterxml/aalto/async/AsyncByteArrayScanner.java
+++ b/src/main/java/com/fasterxml/aalto/async/AsyncByteArrayScanner.java
@@ -4192,18 +4192,6 @@ public class AsyncByteArrayScanner
         throws XMLStreamException
     {
         byte b = _inputBuffer[_inputPtr++]; // we know one is available
-        if (starting) {
-            int ch = (int) b;
-            if (ch < INT_0 || ch > INT_9) { // invalid entity
-                throwUnexpectedChar(decodeCharForError(b), " expected a hex digit (0-9a-fA-F) for character entity");
-            }
-            _pendingInput = PENDING_STATE_ATTR_VALUE_HEX_DIGIT;
-            _entityValue = ch - INT_0;
-            if (_inputPtr >= _inputEnd) {
-                return 0;
-            }
-            b = _inputBuffer[_inputPtr++];
-        }
         while (b != BYTE_SEMICOLON) {
             int ch = (int) b;
             if (ch <= INT_9 && ch >= INT_0) {
@@ -4215,11 +4203,14 @@ public class AsyncByteArrayScanner
             } else {
                 throwUnexpectedChar(decodeCharForError(b), " expected a hex digit (0-9a-fA-F) for character entity");
             }
-            int value = (_entityValue << 4) + ch;
-            _entityValue = value;
-            if (value > MAX_UNICODE_CHAR) { // Overflow?
-                reportEntityOverflow();
+            int value = ch;
+            if (!starting) {
+            	value += (_entityValue << 4);
+                if (value > MAX_UNICODE_CHAR) { // Overflow?
+                    reportEntityOverflow();
+                }
             }
+            _entityValue = value;
             if (_inputPtr >= _inputEnd) {
                 return 0;
             }

--- a/src/test/java/async/Issue40.java
+++ b/src/test/java/async/Issue40.java
@@ -1,0 +1,73 @@
+package async;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.junit.Test;
+
+import com.fasterxml.aalto.AsyncByteArrayFeeder;
+import com.fasterxml.aalto.AsyncXMLInputFactory;
+import com.fasterxml.aalto.AsyncXMLStreamReader;
+import com.fasterxml.aalto.stax.InputFactoryImpl;
+
+/*
+ * According to the XML spec, an hexadecimal character reference can start with a [A-Fa-f].
+ * In the current state of the code, it is not possible.
+ * 
+ *  https://www.w3.org/TR/xml/#NT-Attribute
+ *  Attribute	   ::=   	Name Eq AttValue 
+ *  
+ *  https://www.w3.org/TR/xml/#NT-AttValue
+ *  AttValue	   ::=   	'"' ([^<&"] | Reference)* '"'
+ *                       |  "'" ([^<&'] | Reference)* "'"
+ *
+ *  https://www.w3.org/TR/xml/#NT-Reference
+ *  Reference	   ::=   	EntityRef | CharRef
+ *  
+ *  https://www.w3.org/TR/xml/#NT-CharRef
+ *  CharRef	   ::=   	'&#' [0-9]+ ';'
+ *                    | '&#x' [0-9a-fA-F]+ ';'  <-- here
+ *  
+ */
+public class Issue40 {
+	
+	static AsyncXMLInputFactory FACTORY = new InputFactoryImpl();
+	static String HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><root att=\"";
+	static String FOOTER = "\"></root>";
+
+	@Test
+	public void testHexEntitiesInAttributes() throws XMLStreamException {
+		// non-regression of the fix 
+		testHexEntityInAttribute("&#x0A;", "\n" /*expected string value*/);
+		testHexEntityInAttribute("&#x0a;", "\n" /*expected string value*/);
+		testHexEntityInAttribute("a&#x0A;a", "a\na" /*expected string value*/);
+		testHexEntityInAttribute("a&#x0a;a", "a\na" /*expected string value*/);
+		
+		// unsupported without the fix
+		testHexEntityInAttribute("&#xA;", "\n" /*expected string value*/);
+		testHexEntityInAttribute("&#xa;", "\n" /*expected string value*/);
+		testHexEntityInAttribute("&#xD;&#xA;", "\r\n" /*expected string value*/);
+		testHexEntityInAttribute("&#xd;&#xa;", "\r\n" /*expected string value*/);
+		testHexEntityInAttribute("a&#xA;a", "a\na" /*expected string value*/);
+		testHexEntityInAttribute("a&#xa;a", "a\na" /*expected string value*/);
+		testHexEntityInAttribute("a&#xD;&#xA;a", "a\r\na" /*expected string value*/);
+		testHexEntityInAttribute("a&#xd;&#xa;a", "a\r\na" /*expected string value*/);
+		
+	}
+
+	private void testHexEntityInAttribute(String entity, String expectedStringValue)
+			throws XMLStreamException {
+		AsyncXMLStreamReader<AsyncByteArrayFeeder> parser = FACTORY.createAsyncFor((HEADER + entity + FOOTER).getBytes(StandardCharsets.UTF_8));
+		assertEquals(AsyncXMLStreamReader.START_DOCUMENT, parser.next());
+		assertEquals(AsyncXMLStreamReader.START_ELEMENT, parser.next());
+		assertEquals("root", parser.getName().getLocalPart());
+		assertEquals(expectedStringValue, parser.getAttributeValue(0));
+		assertEquals(AsyncXMLStreamReader.END_ELEMENT, parser.next());
+		assertEquals("root", parser.getName().getLocalPart());
+		
+	}
+	
+}


### PR DESCRIPTION
The parser does not seem to support hexadecimal character references not starting with [0-9] although it is allowed by the XML specification. 
This is a fix proposal with a JUnit test.