### PR TITLE
Fix #53

### DIFF
--- a/src/main/java/com/fasterxml/aalto/async/AsyncByteScanner.java
+++ b/src/main/java/com/fasterxml/aalto/async/AsyncByteScanner.java
@@ -633,6 +633,7 @@ public abstract class AsyncByteScanner
             c == 0xA ||                     //<LF>
             c == 0xD ||                     //<CR>
             c == 0x20 ||                    //<SPACE>
+            (c >= '0' && c <= '9') ||       //[0-9]
             (c >= '@' && c <= 'Z') ||       //@[A-Z]
             (c >= 'a' && c <= 'z') ||
             c == '!' ||

--- a/src/test/java/async/TestDoctypeParsing.java
+++ b/src/test/java/async/TestDoctypeParsing.java
@@ -38,6 +38,20 @@ public class TestDoctypeParsing extends AsyncTestBase
         }
     }
 
+    public void testWithPublicId() throws Exception
+    {
+        final String PUBLIC_ID = "-//W3C//DTD XHTML 1.0 Strict//EN";
+        final String SYSTEM_ID = "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd";
+        for (int spaces = 0; spaces < 3; ++spaces) {
+            String SPC = spaces(spaces);
+            _testWithIds(SPC, 1, PUBLIC_ID, SYSTEM_ID);
+            _testWithIds(SPC, 2, PUBLIC_ID, SYSTEM_ID);
+            _testWithIds(SPC, 3, PUBLIC_ID, SYSTEM_ID);
+            _testWithIds(SPC, 6, PUBLIC_ID, SYSTEM_ID);
+            _testWithIds(SPC, 900, PUBLIC_ID, SYSTEM_ID);
+        }
+    }
+
     public void testParseFull() throws Exception
     {
         for (int spaces = 0; spaces < 3; ++spaces) {
@@ -125,6 +139,10 @@ public class TestDoctypeParsing extends AsyncTestBase
     {
         final String PUBLIC_ID = "-//OASIS//DTD DITA Topic//EN";
         final String SYSTEM_ID = "file:/topic.dtd";
+        _testWithIds(spaces, chunkSize, PUBLIC_ID, SYSTEM_ID);
+    }
+
+    private void _testWithIds(String spaces, int chunkSize, String PUBLIC_ID, String SYSTEM_ID) throws Exception {
         final String XML = spaces + "<!DOCTYPE root PUBLIC '" + PUBLIC_ID + "' \"" + SYSTEM_ID + "\"><root/>";
 
         final AsyncXMLInputFactory f = new InputFactoryImpl();


### PR DESCRIPTION
Adds `[0-9]` to the set of valid Public ID characters in `AsyncByteScanner`, and adds a unit test with the well-known XML 1.0 Strict doctype (`-//W3C//DTD XHTML 1.0 Strict//EN`).