### PR TITLE
fix: retain attribute entity references instead of choking when XMLInpu…

### DIFF
--- a/src/main/java/com/fasterxml/aalto/AaltoInputProperties.java
+++ b/src/main/java/com/fasterxml/aalto/AaltoInputProperties.java
@@ -1,0 +1,10 @@
+package com.fasterxml.aalto;
+
+/**
+ * Class that contains constant for property names used to configure
+ * cursor and event readers produced by Aalto implementation of
+ * {@link javax.xml.stream.XMLInputFactory}.
+ */
+public final class AaltoInputProperties {
+    public final static String P_EXPAND_GENERAL_ENTITIES = "com.fasterxml.aalto.expandGeneralEntities";
+}

--- a/src/main/java/com/fasterxml/aalto/AaltoInputProperties.java
+++ b/src/main/java/com/fasterxml/aalto/AaltoInputProperties.java
@@ -8,9 +8,9 @@ package com.fasterxml.aalto;
 public final class AaltoInputProperties {
 
     /**
-     * Feature controlling whether general entities are expanded or retained.
+     * Feature controlling whether general entities are retained.
      *
      * @since 1.3
      */
-    public final static String P_EXPAND_GENERAL_ENTITIES = "com.fasterxml.aalto.expandGeneralEntities";
+    public final static String P_RETAIN_GENERAL_ENTITIES = "com.fasterxml.aalto.retainGeneralEntities";
 }

--- a/src/main/java/com/fasterxml/aalto/AaltoInputProperties.java
+++ b/src/main/java/com/fasterxml/aalto/AaltoInputProperties.java
@@ -6,5 +6,11 @@ package com.fasterxml.aalto;
  * {@link javax.xml.stream.XMLInputFactory}.
  */
 public final class AaltoInputProperties {
+
+    /**
+     * Feature controlling whether general entities are expanded or retained.
+     *
+     * @since 1.3
+     */
     public final static String P_EXPAND_GENERAL_ENTITIES = "com.fasterxml.aalto.expandGeneralEntities";
 }

--- a/src/main/java/com/fasterxml/aalto/AaltoInputProperties.java
+++ b/src/main/java/com/fasterxml/aalto/AaltoInputProperties.java
@@ -8,9 +8,9 @@ package com.fasterxml.aalto;
 public final class AaltoInputProperties {
 
     /**
-     * Feature controlling whether general entities are retained.
+     * Feature controlling whether general entities in attributes are retained.
      *
      * @since 1.3
      */
-    public final static String P_RETAIN_GENERAL_ENTITIES = "com.fasterxml.aalto.retainGeneralEntities";
+    public final static String P_RETAIN_ATTRIBUTE_GENERAL_ENTITIES = "com.fasterxml.aalto.retainAttributeGeneralEntities";
 }

--- a/src/main/java/com/fasterxml/aalto/in/ReaderConfig.java
+++ b/src/main/java/com/fasterxml/aalto/in/ReaderConfig.java
@@ -42,7 +42,7 @@ public final class ReaderConfig
     final static int F_AUTO_CLOSE_INPUT = 0x2000;
 
     // Custom flags:
-    final static int F_RETAIN_GENERAL_ENTITIES = 0x4000;
+    final static int F_RETAIN_ATTRIBUTE_GENERAL_ENTITIES = 0x4000;
 
     /**
      * These are the default settings for XMLInputFactory.
@@ -101,7 +101,7 @@ public final class ReaderConfig
         sProperties.put(XMLInputFactory2.P_DTD_OVERRIDE, null);
 
         // Custom ones
-        sProperties.put(AaltoInputProperties.P_RETAIN_GENERAL_ENTITIES, Integer.valueOf(F_RETAIN_GENERAL_ENTITIES));
+        sProperties.put(AaltoInputProperties.P_RETAIN_ATTRIBUTE_GENERAL_ENTITIES, Integer.valueOf(F_RETAIN_ATTRIBUTE_GENERAL_ENTITIES));
     }
 
     /**
@@ -283,8 +283,8 @@ public final class ReaderConfig
         setFlag(F_REPORT_CDATA, state);
     }
 
-    public void doRetainGeneralEntities(boolean state) {
-        setFlag(F_RETAIN_GENERAL_ENTITIES, state);
+    public void doRetainAttributeGeneralEntities(boolean state) {
+        setFlag(F_RETAIN_ATTRIBUTE_GENERAL_ENTITIES, state);
     }
     
     /*
@@ -421,7 +421,7 @@ public final class ReaderConfig
 
     // // // Custom properties
 
-    public boolean willRetainGeneralEntities() { return hasFlag(F_RETAIN_GENERAL_ENTITIES); }
+    public boolean willRetainAttributeGeneralEntities() { return hasFlag(F_RETAIN_ATTRIBUTE_GENERAL_ENTITIES); }
 
     /*
     /**********************************************************************

--- a/src/main/java/com/fasterxml/aalto/in/ReaderConfig.java
+++ b/src/main/java/com/fasterxml/aalto/in/ReaderConfig.java
@@ -42,10 +42,10 @@ public final class ReaderConfig
     final static int F_AUTO_CLOSE_INPUT = 0x2000;
 
     // Custom flags:
-    final static int F_EXPAND_GENERAL_ENTITIES = 0x3000;
+    final static int F_RETAIN_GENERAL_ENTITIES = 0x4000;
 
     /**
-     * These are the default settigs for XMLInputFactory.
+     * These are the default settings for XMLInputFactory.
      */
     final static int DEFAULT_FLAGS =
         F_NS_AWARE
@@ -57,8 +57,7 @@ public final class ReaderConfig
         | F_INTERN_NS_URIS
         // and will report CDATA as such (and not as CHARACTERS)
         | F_REPORT_CDATA
-        | F_PRESERVE_LOCATION
-        | F_EXPAND_GENERAL_ENTITIES
+        | F_PRESERVE_LOCATION 
         ;
 
     private final static HashMap<String, Object> sProperties;
@@ -102,7 +101,7 @@ public final class ReaderConfig
         sProperties.put(XMLInputFactory2.P_DTD_OVERRIDE, null);
 
         // Custom ones
-        sProperties.put(AaltoInputProperties.P_EXPAND_GENERAL_ENTITIES, Integer.valueOf(F_EXPAND_GENERAL_ENTITIES));
+        sProperties.put(AaltoInputProperties.P_RETAIN_GENERAL_ENTITIES, Integer.valueOf(F_RETAIN_GENERAL_ENTITIES));
     }
 
     /**
@@ -284,6 +283,10 @@ public final class ReaderConfig
         setFlag(F_REPORT_CDATA, state);
     }
 
+    public void doRetainGeneralEntities(boolean state) {
+        setFlag(F_RETAIN_GENERAL_ENTITIES, state);
+    }
+    
     /*
     /**********************************************************************
     /* Common accessors from CommonConfig
@@ -418,7 +421,7 @@ public final class ReaderConfig
 
     // // // Custom properties
 
-    public boolean willExpandGeneralEntities() { return hasFlag(F_EXPAND_GENERAL_ENTITIES); }
+    public boolean willRetainGeneralEntities() { return hasFlag(F_RETAIN_GENERAL_ENTITIES); }
 
     /*
     /**********************************************************************

--- a/src/main/java/com/fasterxml/aalto/in/ReaderConfig.java
+++ b/src/main/java/com/fasterxml/aalto/in/ReaderConfig.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import javax.xml.stream.*;
 
+import com.fasterxml.aalto.AaltoInputProperties;
 import org.codehaus.stax2.XMLInputFactory2;
 
 import com.fasterxml.aalto.impl.CommonConfig;
@@ -41,6 +42,7 @@ public final class ReaderConfig
     final static int F_AUTO_CLOSE_INPUT = 0x2000;
 
     // Custom flags:
+    final static int F_EXPAND_GENERAL_ENTITIES = 0x3000;
 
     /**
      * These are the default settigs for XMLInputFactory.
@@ -56,6 +58,7 @@ public final class ReaderConfig
         // and will report CDATA as such (and not as CHARACTERS)
         | F_REPORT_CDATA
         | F_PRESERVE_LOCATION
+        | F_EXPAND_GENERAL_ENTITIES
         ;
 
     private final static HashMap<String, Object> sProperties;
@@ -98,7 +101,8 @@ public final class ReaderConfig
         // !!! Not really implemented, but let's recognize it
         sProperties.put(XMLInputFactory2.P_DTD_OVERRIDE, null);
 
-        // Custom ones?
+        // Custom ones
+        sProperties.put(AaltoInputProperties.P_EXPAND_GENERAL_ENTITIES, Integer.valueOf(F_EXPAND_GENERAL_ENTITIES));
     }
 
     /**
@@ -412,6 +416,9 @@ public final class ReaderConfig
 
     public boolean hasInternNsURIsBeenEnabled() { return hasExplicitFlag(F_INTERN_NS_URIS); }
 
+    // // // Custom properties
+
+    public boolean willExpandGeneralEntities() { return hasFlag(F_EXPAND_GENERAL_ENTITIES); }
 
     /*
     /**********************************************************************

--- a/src/main/java/com/fasterxml/aalto/in/ReaderScanner.java
+++ b/src/main/java/com/fasterxml/aalto/in/ReaderScanner.java
@@ -830,7 +830,7 @@ public final class ReaderScanner
      * simplify main method, which makes code more maintainable
      * and possibly easier for JIT/HotSpot to optimize.
      */
-    private final int collectValue(int attrPtr, char quoteChar, PName attrName)
+    private int collectValue(int attrPtr, char quoteChar, PName attrName)
         throws XMLStreamException
     {
         char[] attrBuffer = _attrCollector.startNewValue(attrName, attrPtr);
@@ -896,7 +896,7 @@ public final class ReaderScanner
                     throwUnexpectedChar(c, "'<' not allowed in attribute value");
                 case XmlCharTypes.CT_AMP:
                     {
-                        if (!_config.willRetainGeneralEntities()) {
+                        if (!_config.willRetainAttributeGeneralEntities()) {
                             int d = handleEntityInText(false);
                             if (d == 0) { // unexpanded general entity... not good
                                 reportUnexpandedEntityInAttr(attrName, false);

--- a/src/main/java/com/fasterxml/aalto/in/ReaderScanner.java
+++ b/src/main/java/com/fasterxml/aalto/in/ReaderScanner.java
@@ -896,20 +896,22 @@ public final class ReaderScanner
                     throwUnexpectedChar(c, "'<' not allowed in attribute value");
                 case XmlCharTypes.CT_AMP:
                     {
-                        int d = handleEntityInText(false);
-                        if (d == 0) { // unexpanded general entity... not good
-                            reportUnexpandedEntityInAttr(attrName, false);
-                        }
-                        // Ok; does it need a surrogate though? (over 16 bits)
-                        if ((d >> 16) != 0) {
-                            d -= 0x10000;
-                            attrBuffer[attrPtr++] = (char) (0xD800 | (d >> 10));
-                            d = 0xDC00 | (d & 0x3FF);
-                            if (attrPtr >= attrBuffer.length) {
-                                attrBuffer = _attrCollector.valueBufferFull();
+                        if (_config.willExpandEntities()) {
+                            int d = handleEntityInText(false);
+                            if (d == 0) { // unexpanded general entity... not good
+                                reportUnexpandedEntityInAttr(attrName, false);
                             }
+                            // Ok; does it need a surrogate though? (over 16 bits)
+                            if ((d >> 16) != 0) {
+                                d -= 0x10000;
+                                attrBuffer[attrPtr++] = (char) (0xD800 | (d >> 10));
+                                d = 0xDC00 | (d & 0x3FF);
+                                if (attrPtr >= attrBuffer.length) {
+                                    attrBuffer = _attrCollector.valueBufferFull();
+                                }
+                            }
+                            c = (char) d;
                         }
-                        c = (char) d;
                     }
                     break;
                 case XmlCharTypes.CT_ATTR_QUOTE:

--- a/src/main/java/com/fasterxml/aalto/in/ReaderScanner.java
+++ b/src/main/java/com/fasterxml/aalto/in/ReaderScanner.java
@@ -896,7 +896,7 @@ public final class ReaderScanner
                     throwUnexpectedChar(c, "'<' not allowed in attribute value");
                 case XmlCharTypes.CT_AMP:
                     {
-                        if (_config.willExpandGeneralEntities()) {
+                        if (!_config.willRetainGeneralEntities()) {
                             int d = handleEntityInText(false);
                             if (d == 0) { // unexpanded general entity... not good
                                 reportUnexpandedEntityInAttr(attrName, false);

--- a/src/main/java/com/fasterxml/aalto/in/ReaderScanner.java
+++ b/src/main/java/com/fasterxml/aalto/in/ReaderScanner.java
@@ -896,7 +896,7 @@ public final class ReaderScanner
                     throwUnexpectedChar(c, "'<' not allowed in attribute value");
                 case XmlCharTypes.CT_AMP:
                     {
-                        if (_config.willExpandEntities()) {
+                        if (_config.willExpandGeneralEntities()) {
                             int d = handleEntityInText(false);
                             if (d == 0) { // unexpanded general entity... not good
                                 reportUnexpandedEntityInAttr(attrName, false);

--- a/src/main/java/com/fasterxml/aalto/sax/SAXParserFactoryImpl.java
+++ b/src/main/java/com/fasterxml/aalto/sax/SAXParserFactoryImpl.java
@@ -70,7 +70,7 @@ public class SAXParserFactoryImpl
             case IS_STANDALONE: // read-only, but only during parsing
                 return true;
             case EXTERNAL_GENERAL_ENTITIES:
-                return ((Boolean) mStaxFactory.getProperty(AaltoInputProperties.P_EXPAND_GENERAL_ENTITIES)).booleanValue();
+                return !((Boolean) mStaxFactory.getProperty(AaltoInputProperties.P_RETAIN_GENERAL_ENTITIES)).booleanValue();
             default:
             }
         } else {
@@ -98,7 +98,7 @@ public class SAXParserFactoryImpl
 
             switch (stdFeat) {
             case EXTERNAL_GENERAL_ENTITIES:
-                mStaxFactory.setProperty(AaltoInputProperties.P_EXPAND_GENERAL_ENTITIES, enabled);
+                mStaxFactory.setProperty(AaltoInputProperties.P_RETAIN_GENERAL_ENTITIES, !enabled);
                 ok = true;
                 break;
             case EXTERNAL_PARAMETER_ENTITIES:

--- a/src/main/java/com/fasterxml/aalto/sax/SAXParserFactoryImpl.java
+++ b/src/main/java/com/fasterxml/aalto/sax/SAXParserFactoryImpl.java
@@ -18,6 +18,7 @@ package com.fasterxml.aalto.sax;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import com.fasterxml.aalto.AaltoInputProperties;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 
@@ -36,11 +37,6 @@ public class SAXParserFactoryImpl
     extends SAXParserFactory
 {
     final InputFactoryImpl mStaxFactory;
-
-    public SAXParserFactoryImpl(InputFactoryImpl inputFactory)
-    {   
-        mStaxFactory = inputFactory;
-    }
     
     public SAXParserFactoryImpl()
     {
@@ -73,6 +69,8 @@ public class SAXParserFactoryImpl
             switch (stdFeat) {
             case IS_STANDALONE: // read-only, but only during parsing
                 return true;
+            case EXTERNAL_GENERAL_ENTITIES:
+                return ((Boolean) mStaxFactory.getProperty(AaltoInputProperties.P_EXPAND_GENERAL_ENTITIES)).booleanValue();
             default:
             }
         } else {
@@ -100,7 +98,8 @@ public class SAXParserFactoryImpl
 
             switch (stdFeat) {
             case EXTERNAL_GENERAL_ENTITIES:
-                ok = !enabled;
+                mStaxFactory.setProperty(AaltoInputProperties.P_EXPAND_GENERAL_ENTITIES, enabled);
+                ok = true;
                 break;
             case EXTERNAL_PARAMETER_ENTITIES:
                 ok = !enabled;

--- a/src/main/java/com/fasterxml/aalto/sax/SAXParserFactoryImpl.java
+++ b/src/main/java/com/fasterxml/aalto/sax/SAXParserFactoryImpl.java
@@ -37,6 +37,11 @@ public class SAXParserFactoryImpl
 {
     final InputFactoryImpl mStaxFactory;
 
+    public SAXParserFactoryImpl(InputFactoryImpl inputFactory)
+    {   
+        mStaxFactory = inputFactory;
+    }
+    
     public SAXParserFactoryImpl()
     {
         // defaults should be fine...

--- a/src/main/java/com/fasterxml/aalto/sax/SAXParserFactoryImpl.java
+++ b/src/main/java/com/fasterxml/aalto/sax/SAXParserFactoryImpl.java
@@ -70,7 +70,7 @@ public class SAXParserFactoryImpl
             case IS_STANDALONE: // read-only, but only during parsing
                 return true;
             case EXTERNAL_GENERAL_ENTITIES:
-                return !((Boolean) mStaxFactory.getProperty(AaltoInputProperties.P_RETAIN_GENERAL_ENTITIES)).booleanValue();
+                return Boolean.FALSE.equals(mStaxFactory.getProperty(AaltoInputProperties.P_RETAIN_ATTRIBUTE_GENERAL_ENTITIES));
             default:
             }
         } else {
@@ -98,7 +98,7 @@ public class SAXParserFactoryImpl
 
             switch (stdFeat) {
             case EXTERNAL_GENERAL_ENTITIES:
-                mStaxFactory.setProperty(AaltoInputProperties.P_RETAIN_GENERAL_ENTITIES, !enabled);
+                mStaxFactory.setProperty(AaltoInputProperties.P_RETAIN_ATTRIBUTE_GENERAL_ENTITIES, !enabled);
                 ok = true;
                 break;
             case EXTERNAL_PARAMETER_ENTITIES:

--- a/src/main/java/com/fasterxml/aalto/sax/SAXParserImpl.java
+++ b/src/main/java/com/fasterxml/aalto/sax/SAXParserImpl.java
@@ -264,7 +264,7 @@ class SAXParserImpl
                 // !!! TBI
                 return true;
             case EXTERNAL_GENERAL_ENTITIES:
-                return !((Boolean) _staxFactory.getProperty(AaltoInputProperties.P_RETAIN_GENERAL_ENTITIES)).booleanValue();     
+                return Boolean.FALSE.equals(_staxFactory.getProperty(AaltoInputProperties.P_RETAIN_ATTRIBUTE_GENERAL_ENTITIES));
             default:
             }
         } else {

--- a/src/main/java/com/fasterxml/aalto/sax/SAXParserImpl.java
+++ b/src/main/java/com/fasterxml/aalto/sax/SAXParserImpl.java
@@ -22,6 +22,7 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
+import com.fasterxml.aalto.AaltoInputProperties;
 import org.xml.sax.*;
 import org.xml.sax.ext.Attributes2;
 import org.xml.sax.ext.DeclHandler;
@@ -262,6 +263,8 @@ class SAXParserImpl
             case IS_STANDALONE: // read-only, but only during parsing
                 // !!! TBI
                 return true;
+            case EXTERNAL_GENERAL_ENTITIES:
+                return ((Boolean) _staxFactory.getProperty(AaltoInputProperties.P_EXPAND_GENERAL_ENTITIES)).booleanValue();     
             default:
             }
         } else {

--- a/src/main/java/com/fasterxml/aalto/sax/SAXParserImpl.java
+++ b/src/main/java/com/fasterxml/aalto/sax/SAXParserImpl.java
@@ -264,7 +264,7 @@ class SAXParserImpl
                 // !!! TBI
                 return true;
             case EXTERNAL_GENERAL_ENTITIES:
-                return ((Boolean) _staxFactory.getProperty(AaltoInputProperties.P_EXPAND_GENERAL_ENTITIES)).booleanValue();     
+                return !((Boolean) _staxFactory.getProperty(AaltoInputProperties.P_RETAIN_GENERAL_ENTITIES)).booleanValue();     
             default:
             }
         } else {

--- a/src/main/java/com/fasterxml/aalto/sax/SAXUtil.java
+++ b/src/main/java/com/fasterxml/aalto/sax/SAXUtil.java
@@ -71,8 +71,6 @@ public final class SAXUtil
     public static Boolean getFixedStdFeatureValue(SAXFeature stdFeat)
     {
         switch (stdFeat) {
-        case EXTERNAL_GENERAL_ENTITIES: // not yet implemented
-            return Boolean.FALSE;
         case EXTERNAL_PARAMETER_ENTITIES: // not yet implemented
             return Boolean.FALSE;
         case IS_STANDALONE: // read-only, but only during parsing

--- a/src/test/java/com/fasterxml/aalto/sax/TestEntityResolver.java
+++ b/src/test/java/com/fasterxml/aalto/sax/TestEntityResolver.java
@@ -1,13 +1,14 @@
 package com.fasterxml.aalto.sax;
 
 import java.io.*;
+import java.util.concurrent.CountDownLatch;
 
 import javax.xml.parsers.SAXParser;
+import javax.xml.stream.XMLInputFactory;
 
+import com.fasterxml.aalto.stax.InputFactoryImpl;
 import org.xml.sax.*;
 import org.xml.sax.helpers.DefaultHandler;
-
-import com.fasterxml.aalto.sax.*;
 
 /**
  * Simple unit tests to verify that most fundamental parsing functionality
@@ -49,6 +50,46 @@ public class TestEntityResolver
         }
     }
 
+    public void testRetainAttributeEntityReference()
+            throws Exception
+    {
+        final String XML =
+                "<!DOCTYPE root PUBLIC '//some//public//id' 'no-such-thing.dtd'>\n"
+                        +"<root b=\"&replace-me;\" />";
+
+        SAXParserFactoryImpl spf = new SAXParserFactoryImpl();
+        SAXParser sp = spf.newSAXParser();
+        DefaultHandler h = new DefaultHandler();
+        
+        try {
+            sp.parse(new InputSource(new StringReader(XML)), h);
+            fail();
+        } catch (SAXException e) {
+            verifyException(e, "General entity reference (&replace-me;) encountered in entity expanding mode: operation not (yet) implemented\n at [row,col {unknown-source}]: [2,22]");
+        }
+
+        InputFactoryImpl inputFactory = new InputFactoryImpl();
+        inputFactory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+        SAXParserFactoryImpl spfKeepEntityReferences = new SAXParserFactoryImpl(inputFactory);
+        spfKeepEntityReferences.setNamespaceAware(true);
+        SAXParser spKeepEntityReferences = spfKeepEntityReferences.newSAXParser();
+
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        spKeepEntityReferences.parse(new InputSource(new StringReader(XML)), new DefaultHandler() {
+            @Override
+            public void startElement(String uri, String localName, String qName, Attributes attributes) {
+                assertEquals("root", localName);
+                assertEquals("root", qName);
+                assertEquals(1, attributes.getLength());
+                assertEquals("&replace-me;", attributes.getValue(0));
+
+                countDownLatch.countDown();
+            }
+        });
+        
+        assertEquals(0, countDownLatch.getCount());
+    }
+    
     static class MyResolver
         implements EntityResolver
     {

--- a/src/test/java/com/fasterxml/aalto/sax/TestEntityResolver.java
+++ b/src/test/java/com/fasterxml/aalto/sax/TestEntityResolver.java
@@ -67,11 +67,9 @@ public class TestEntityResolver
         } catch (SAXException e) {
             verifyException(e, "General entity reference (&replace-me;) encountered in entity expanding mode: operation not (yet) implemented\n at [row,col {unknown-source}]: [2,22]");
         }
-
-        InputFactoryImpl inputFactory = new InputFactoryImpl();
-        inputFactory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
-        SAXParserFactoryImpl spfKeepEntityReferences = new SAXParserFactoryImpl(inputFactory);
-        spfKeepEntityReferences.setNamespaceAware(true);
+        
+        SAXParserFactoryImpl spfKeepEntityReferences = new SAXParserFactoryImpl();
+        spfKeepEntityReferences.setFeature("http://xml.org/sax/features/external-general-entities", false);
         SAXParser spKeepEntityReferences = spfKeepEntityReferences.newSAXParser();
 
         final CountDownLatch countDownLatch = new CountDownLatch(1);

--- a/src/test/java/com/fasterxml/aalto/sax/TestSAXParserFactoryImpl.java
+++ b/src/test/java/com/fasterxml/aalto/sax/TestSAXParserFactoryImpl.java
@@ -1,0 +1,17 @@
+package com.fasterxml.aalto.sax;
+
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
+public class TestSAXParserFactoryImpl extends base.BaseTestCase {
+    
+    public void testSetGetFeatureExternalGeneralEntities() throws SAXNotRecognizedException, SAXNotSupportedException {
+        SAXParserFactoryImpl saxParserFactory = new SAXParserFactoryImpl();
+        saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        assertFalse(saxParserFactory.getFeature("http://xml.org/sax/features/external-general-entities"));
+
+        saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", true);
+        assertTrue(saxParserFactory.getFeature("http://xml.org/sax/features/external-general-entities"));
+    }
+    
+}


### PR DESCRIPTION
…tFactory.IS_REPLACING_ENTITY_REFERENCES is set to false

allow SAXParserFactoryImpl to be customised

Refs: aalto-xml#65