### PR TITLE
Fixing a bug when multi-byte characters were split

### DIFF
--- a/src/main/java/com/fasterxml/aalto/out/ByteXmlWriter.java
+++ b/src/main/java/com/fasterxml/aalto/out/ByteXmlWriter.java
@@ -390,7 +390,7 @@ public abstract class ByteXmlWriter
             flushBuffer();
         }
         _outputBuffer[_outputPtr++] = BYTE_GT;
-    }    
+    }
 
     @Override
     public void writeStartTagEmptyEnd()
@@ -435,7 +435,7 @@ public abstract class ByteXmlWriter
         ptr += name.appendBytes(bbuf, ptr);
         bbuf[ptr++] = BYTE_GT;
         _outputPtr = ptr;
-    }    
+    }
 
     /*
     /**********************************************************************
@@ -572,6 +572,8 @@ public abstract class ByteXmlWriter
     {
         if (_surrogate != 0) {
             outputSurrogates(_surrogate, vbuf[offset]);
+//           reset the temporary surrogate storage
+            _surrogate = 0;
             ++offset;
             --len;
         }
@@ -785,7 +787,7 @@ public abstract class ByteXmlWriter
             writeCDataEnd(); // will check surrogates
         }
         return ix;
-    }    
+    }
 
     protected int writeCDataContents(char[] cbuf, int offset, int len)
         throws IOException, XMLStreamException
@@ -865,7 +867,7 @@ public abstract class ByteXmlWriter
             }
         }
         return -1;
-    }    
+    }
 
     @Override
     public final void writeCharacters(String text)
@@ -908,6 +910,8 @@ public abstract class ByteXmlWriter
     {
         if (_surrogate != 0) {
             outputSurrogates(_surrogate, cbuf[offset]);
+//           reset the temporary surrogate storage
+            _surrogate = 0;
             ++offset;
             --len;
         }
@@ -1088,7 +1092,7 @@ public abstract class ByteXmlWriter
             }
             _outputBuffer[_outputPtr++] = (byte)ch;
         }
-    }    
+    }
 
     /*
     /**********************************************************************
@@ -1439,7 +1443,7 @@ public abstract class ByteXmlWriter
         // !!! TBI: check validity
         writeRaw(version, 0, version.length());
         writeRaw(BYTE_APOS);
-        
+
         if (encoding != null && encoding.length() > 0) {
             writeRaw(BYTES_XMLDECL_ENCODING);
             // !!! TBI: check validity
@@ -1453,7 +1457,7 @@ public abstract class ByteXmlWriter
             writeRaw(BYTE_APOS);
         }
         writeRaw(BYTE_QMARK, BYTE_GT);
-    }    
+    }
 
     /*
     /**********************************************************************
@@ -1594,7 +1598,7 @@ public abstract class ByteXmlWriter
     protected final void writeAsEntity(int c)
         throws IOException
     {
-        // Quickie check to avoid 
+        // Quickie check to avoid
 
         byte[] buf = _outputBuffer;
         int ptr = _outputPtr;

--- a/src/test/java/com/fasterxml/aalto/sax/TestSaxWriter.java
+++ b/src/test/java/com/fasterxml/aalto/sax/TestSaxWriter.java
@@ -1,0 +1,57 @@
+package com.fasterxml.aalto.sax;
+
+import com.fasterxml.aalto.out.Utf8XmlWriter;
+import com.fasterxml.aalto.out.WriterConfig;
+
+import java.io.ByteArrayOutputStream;
+
+public class TestSaxWriter extends base.BaseTestCase {
+
+    public void testSurrogateMemory1() throws Exception {
+        // This test aims to produce the
+        // javax.xml.stream.XMLStreamException: Incomplete surrogate pair in content: first char 0xd835, second 0x78
+        // error message. Before fixing the respective issue, it was provoked by a multi-byte character
+        // where the first byte was exactly at the end of the internal reading buffer and enough further data
+        // to also fill the next two internal reading buffers. Then, the code would try to fuse the first byte
+        // of the original multi-byte character with the first character in the third buffer because
+        // ByteXmlWriter#_surrogate was not set back to 0 after writing the original multi-byte character.
+        StringBuilder testText = new StringBuilder();
+        for (int i = 0; i < 511; i++)
+            testText.append('x');
+        testText.append("\uD835\uDFCE");
+        for (int i = 0; i < 512; i++)
+            testText.append('x');
+
+        WriterConfig writerConfig = new WriterConfig();
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        Utf8XmlWriter writer = new Utf8XmlWriter(writerConfig, byteArrayOutputStream);
+        writer.writeStartTagStart(writer.constructName("testelement"));
+        writer.writeAttribute(writer.constructName("testattr"), testText.toString());
+        writer.writeStartTagEnd();
+        writer.writeEndTag(writer.constructName("testelement"));
+        writer.close(false);
+    }
+
+    public void testSurrogateMemory2() throws Exception {
+        // This test aims to produce the
+        // java.io.IOException: Unpaired surrogate character (0xd835)
+        // error message. Before fixing the respective issue, it was provoked by a multi-byte character
+        // where the first byte was exactly at the end of the internal reading buffer and the next
+        // reading buffer was enough to write all the remaining data. Then, by the missing reset of
+        // ByteXmlWriter#_surrogate, the code expected another multi-byte surrogate that never came.
+        StringBuilder testText = new StringBuilder();
+        for (int i = 0; i < 511; i++)
+            testText.append('x');
+        testText.append("\uD835\uDFCE");
+
+        WriterConfig writerConfig = new WriterConfig();
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        Utf8XmlWriter writer = new Utf8XmlWriter(writerConfig, byteArrayOutputStream);
+        writer.writeStartTagStart(writer.constructName("testelement"));
+        writer.writeAttribute(writer.constructName("testattr"), testText.toString());
+        writer.writeStartTagEnd();
+        writer.writeEndTag(writer.constructName("testelement"));
+        writer.close(false);
+        System.out.println(byteArrayOutputStream);
+    }
+}

--- a/src/test/java/com/fasterxml/aalto/sax/TestSaxWriter.java
+++ b/src/test/java/com/fasterxml/aalto/sax/TestSaxWriter.java
@@ -30,6 +30,7 @@ public class TestSaxWriter extends base.BaseTestCase {
         writer.writeStartTagEnd();
         writer.writeEndTag(writer.constructName("testelement"));
         writer.close(false);
+
     }
 
     public void testSurrogateMemory2() throws Exception {
@@ -52,6 +53,5 @@ public class TestSaxWriter extends base.BaseTestCase {
         writer.writeStartTagEnd();
         writer.writeEndTag(writer.constructName("testelement"));
         writer.close(false);
-        System.out.println(byteArrayOutputStream);
     }
 }


### PR DESCRIPTION
The `_surrogate` field in `ByteXmlWriter` serves as a memory across buffers in these cases. However, after writing the original multi-byte character, the field was not set back to 0 which caused the XmlWriter to think there were another surrogate pair where there were none.

This could cause two sorts of errors for which this PR provides new tests. Both tests will fail when the reset of `_surrogate` is removed.