### PR TITLE
Using XMLConstants.DEFAULT_NS_PREFIX as prefix in alto.in.NsBinding#createDefaultNs.

### DIFF
--- a/src/main/java/com/fasterxml/aalto/in/NsBinding.java
+++ b/src/main/java/com/fasterxml/aalto/in/NsBinding.java
@@ -48,7 +48,7 @@ final class NsBinding
          * bindings for "xml" or "xmlns". These should be catched earlier,
          * but just in case they aren't let's verify them here.
          */
-        if (prefix == "xml" || prefix == "xmlns") {
+        if ("xml".equals(prefix) || "xmlns".equals(prefix)) {
             throw new RuntimeException("Trying to create non-singleton binding for ns prefix '"+prefix+"'");
         }
         mPrefix = prefix;
@@ -56,7 +56,7 @@ final class NsBinding
     }
 
     public final static NsBinding createDefaultNs() {
-        return new NsBinding(null);
+        return new NsBinding(XMLConstants.DEFAULT_NS_PREFIX);
     }
 
     private NsBinding(String prefix, String uri, Object DUMMY)

--- a/src/test/java/com/fasterxml/aalto/in/FixedNsContextTest.java
+++ b/src/test/java/com/fasterxml/aalto/in/FixedNsContextTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fasterxml.aalto.in;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import javax.xml.XMLConstants;
+
+public class FixedNsContextTest extends TestCase {
+
+    public void testFixedNsContextDefaultNsNull() {
+        NsBinding defaultNs = NsBinding.createDefaultNs();
+
+        NsDeclaration sut = new NsDeclaration(defaultNs, null, null, 0);
+        sut = new NsDeclaration(new NsBinding("xyz"), "https://xyz.yzx", sut, 0);
+
+        FixedNsContext fixedNsContext = FixedNsContext.EMPTY_CONTEXT.reuseOrCreate(sut);
+
+        Assert.assertEquals(null, fixedNsContext.getNamespaceURI(XMLConstants.DEFAULT_NS_PREFIX));
+
+        Assert.assertEquals("https://xyz.yzx", fixedNsContext.getNamespaceURI("xyz"));
+        Assert.assertEquals("xyz", fixedNsContext.getPrefix("https://xyz.yzx"));
+    }
+
+    public void testFixedNsContextEmptyDefaultNsNotNull() {
+        NsBinding defaultNs = NsBinding.createDefaultNs();
+
+        NsDeclaration sut = new NsDeclaration(defaultNs, "http://localhost/", null, 0);
+        sut = new NsDeclaration(new NsBinding("xyz"), "https://xyz.yzx", sut, 0);
+
+        FixedNsContext fixedNsContext = FixedNsContext.EMPTY_CONTEXT.reuseOrCreate(sut);
+
+        Assert.assertEquals("http://localhost/", fixedNsContext.getNamespaceURI(XMLConstants.DEFAULT_NS_PREFIX));
+        Assert.assertEquals(XMLConstants.DEFAULT_NS_PREFIX, fixedNsContext.getPrefix("http://localhost/"));
+
+        Assert.assertEquals("https://xyz.yzx", fixedNsContext.getNamespaceURI("xyz"));
+        Assert.assertEquals("xyz", fixedNsContext.getPrefix("https://xyz.yzx"));
+    }
+
+}

--- a/src/test/java/com/fasterxml/aalto/in/NsBindingTest.java
+++ b/src/test/java/com/fasterxml/aalto/in/NsBindingTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fasterxml.aalto.in;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import javax.xml.XMLConstants;
+
+public class NsBindingTest extends TestCase {
+
+    public void testCreateDefaultNs() {
+        NsBinding defaultNS = NsBinding.createDefaultNs();
+        Assert.assertEquals("Prefix of default namespace should be " + XMLConstants.DEFAULT_NS_PREFIX, XMLConstants.DEFAULT_NS_PREFIX, defaultNS.mPrefix);
+    }
+
+
+}


### PR DESCRIPTION
Fix for: `https://github.com/FasterXML/aalto-xml/issues/97` 

- alto.in.NsBinding#createDefaultNs now uses XMLConstants.DEFAULT_NS_PREFIX as prefix.
- added tests with expected behaviour after fix
  - com.fasterxml.aalto.in.NsBindingTest
  - com.fasterxml.aalto.in.FixedNsContextTest